### PR TITLE
Fix: Allow JS Clipboard

### DIFF
--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -43,6 +43,8 @@ Item {
 
         profile: webProfile
 
+        settings.javascriptCanAccessClipboard: true
+
         onLinkHovered: hoveredUrl => {
             if (hoveredUrl.toString() !== "") {
                 mouseArea.cursorShape = Qt.PointingHandCursor;


### PR DESCRIPTION
Allow JS to access clipboard (so you can copy code from ChatGPT from the "Copy" button, for example).