### PR TITLE
Feat: Add Google Gemini and BlackBox AI

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -42,6 +42,12 @@
     <entry name="showHugginChat" type="Bool">
       <default>true</default>
     </entry>
+    <entry name="showGoogleGemini" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="showBlackBox" type="Bool">
+      <default>false</default>
+    </entry>
     <entry name="showBingCopilot" type="Bool">
       <default>false</default>
     </entry>

--- a/contents/ui/ConfigGeneral.qml
+++ b/contents/ui/ConfigGeneral.qml
@@ -45,6 +45,22 @@ KCM.SimpleKCM {
 
         RowLayout {
             QQC2.CheckBox {
+                id: showHugginChat
+
+                text: qsTr("Google Gemini")
+            }
+        }
+
+        RowLayout {
+            QQC2.CheckBox {
+                id: showHugginChat
+
+                text: qsTr("BlackBox AI")
+            }
+        }
+
+        RowLayout {
+            QQC2.CheckBox {
                 id: showBingCopilot
 
                 text: qsTr("Bing Copilot")

--- a/contents/ui/Header.qml
+++ b/contents/ui/Header.qml
@@ -98,6 +98,10 @@ RowLayout {
             plasmoid.configuration.showHugginChat && chatModel.push({ value: "https://huggingface.co/chat", text: "HugginChat" })
 
             plasmoid.configuration.showBingCopilot && chatModel.push({ value: "https://www.bing.com/chat", text: "Bing Copilot" })
+            
+            plasmoid.configuration.showGoogleGemini && chatModel.push({ value: "https://gemini.google.com/app", text: "Google Gemini" })
+
+            plasmoid.configuration.showBlackBox && chatModel.push({ value: "https://www.blackbox.ai", text: "BlackBox AI" })
 
             urlComboBox.model = chatModel
 


### PR DESCRIPTION
Add Google Gemini and BlackBox AI as new options.

BlackBox AI is disabled by default (as Bing Copilot) because they aren't responsive as the other options.