### PR TITLE
feat: blur, transparency, UI improvements and fixes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# ChatAI Plasmoid
+
+KDE Plasma 6 widget that embeds AI chat services (ChatGPT, Claude, Gemini, DuckDuckGo, DeepSeek, etc.) in a panel popup using QtWebEngine.
+
+## Architecture
+
+Pure QML plasmoid — no C++, no build system. Installed via KDE package manager.
+
+```
+contents/
+  config/
+    main.xml          # KDE configuration schema (all settings)
+    config.qml        # Config tab definitions (General + Appearance)
+  ui/
+    main.qml          # PlasmoidItem root, popup layout, header auto-hide, WebView loader
+    WebView.qml       # WebEngineView, permissions, downloads, context menu, JS injection
+    Header.qml        # Navigation bar, URL selector, control buttons (Item wrapping RowLayout)
+    CompactRepresentation.qml  # Panel icon with dynamic icon modes
+    ConfigGeneral.qml          # Settings: sites, permissions, web features, downloads, cache
+    ConfigAppearance.qml       # Settings: icon, effects, transparency, focus mode, header options
+    FindBar.qml        # Ctrl+F find-in-page bar
+    DownloadBar.qml    # Download progress/cancel/open UI
+```
+
+## Key patterns
+
+- **Configuration**: all settings in `main.xml`, accessed via `plasmoid.configuration.propertyName`
+- **Signals**: Header communicates with main.qml via signals (goBackToHomePage, navigateBackRequested, etc.)
+- **JS injection**: WebView injects CSS/JS into pages for: browser spoofing, transparency, focus mode, keyboard shortcuts
+- **Heuristic DOM analysis**: transparency and focus mode analyze page structure to find sidebars, headers, input areas
+- **WebEngine lifecycle**: configurable keep-alive (instant reopen) or 5-min idle unload (memory saving)
+
+## Important constraints
+
+- `PlasmaExtras.Menu`/`MenuItem` do NOT exist in Plasma 6 — use `PlasmaComponents3.Menu`/`MenuItem`
+- `PlasmaComponents3.Menu` cannot be a root type in a separate QML file (causes "Type cannot be created in QML")
+- `import org.kde.notification` MUST keep version `1.0` (unversioned fails at runtime)
+- `MultiEffect` blur cannot affect WebEngineView content (native surface) — use CSS injection instead
+- `backgroundHints` is set via `Plasmoid.backgroundHints` (attached property), not directly on PlasmoidItem
+- Header.qml root is `Item` (not `RowLayout`) — signals, properties, and functions must be on the Item, not inside the RowLayout
+
+## Configuration properties
+
+Settings are split across two tabs:
+
+**General** (ConfigGeneral.qml): site toggles (showChatGPT, showClaude, etc.), custom sites, permissions (mic/webcam/screenshare/notifications/geolocation), web features (JS clipboard, spatial nav), download path, cache management, profile name, keepWebEngineAlive, spoofChromeBrowser
+
+**Appearance** (ConfigAppearance.qml): iconMode, animations, header gradient, accent glow, focus mode, transparency + opacity slider, header visibility toggles
+
+## JS injection layers (WebView.qml)
+
+Applied on every page load via `onLoadingChanged`:
+
+1. **Browser spoof** (`injectBrowserSpoof`): Chrome 130 UA, navigator.vendor/platform/plugins, window.chrome object
+2. **Transparency** (`injectTransparencyCSS`): heuristic DOM walk, classifies elements as chrome/background/chat, applies layered rgba + backdrop-blur
+3. **Focus mode** (`injectFocusMode`): per-site CSS rules + heuristic fallback hiding nav/aside/header/sidebar
+4. **Keyboard shortcuts**: Enter-to-send for compatible services (DuckDuckGo, ChatGPT, Gemini, Claude, You)
+
+## Testing
+
+No automated tests. Test by:
+1. Installing: `plasmashell --replace &` or remove/re-add widget
+2. Check logs: `journalctl --user -u plasma-plasmashell -b | grep -i "chatai\|webview\|error"`
+3. Lint: `qmllint contents/ui/*.qml` (ignore "Library import requires a version" warnings)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ A range of chatbots as Plasmoid for your KDE Plasma desktop
                 </a>
             </td>
             <td align="center">
+                <a href="https://github.com/postadelmaga">
+                    <img src="https://avatars.githubusercontent.com/u/2010800?v=4" width="100;" alt="postadelmaga"/>
+                    <br />
+                    <sub><b>postadelmaga</b></sub>
+                </a>
+            </td>
+            <td align="center">
                 <a href="https://github.com/bigbruno">
                     <img src="https://avatars.githubusercontent.com/u/6098501?v=4" width="100;" alt="bigbruno"/>
                     <br />
@@ -34,13 +41,6 @@ A range of chatbots as Plasmoid for your KDE Plasma desktop
                     <img src="https://avatars.githubusercontent.com/u/90243579?v=4" width="100;" alt="meowarex"/>
                     <br />
                     <sub><b>Meow Meow</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/RevengeRip">
-                    <img src="https://avatars.githubusercontent.com/u/9915567?v=4" width="100;" alt="RevengeRip"/>
-                    <br />
-                    <sub><b>RevengeRip</b></sub>
                 </a>
             </td>
             <td align="center">

--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ A range of chatbots as Plasmoid for your KDE Plasma desktop
 	<tbody>
 		<tr>
             <td align="center">
-                <a href="https://github.com/DenysMb">
-                    <img src="https://avatars.githubusercontent.com/u/33737137?v=4" width="100;" alt="DenysMb"/>
-                    <br />
-                    <sub><b>Denys Madureira</b></sub>
-                </a>
-            </td>
-            <td align="center">
                 <a href="https://github.com/postadelmaga">
                     <img src="https://avatars.githubusercontent.com/u/2010800?v=4" width="100;" alt="postadelmaga"/>
                     <br />
                     <sub><b>postadelmaga</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/DenysMb">
+                    <img src="https://avatars.githubusercontent.com/u/33737137?v=4" width="100;" alt="DenysMb"/>
+                    <br />
+                    <sub><b>Denys Madureira</b></sub>
                 </a>
             </td>
             <td align="center">

--- a/README.md
+++ b/README.md
@@ -50,13 +50,6 @@ A range of chatbots as Plasmoid for your KDE Plasma desktop
                     <sub><b>Vitor Dantas</b></sub>
                 </a>
             </td>
-            <td align="center">
-                <a href="https://github.com/postadelmaga">
-                    <img src="https://avatars.githubusercontent.com/u/2010800?v=4" width="100;" alt="postadelmaga"/>
-                    <br />
-                    <sub><b>postadelmaga</b></sub>
-                </a>
-            </td>
 		</tr>
 	<tbody>
 </table>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -17,11 +17,9 @@
       <default>1</default>
     </entry>
     <entry name="favIcon" type="String">
-      <label>Base64 encoded favicon from website</label>
       <default></default>
     </entry>
     <entry name="lastFavIcon" type="String">
-      <label>Last successfully loaded favicon URL</label>
       <default></default>
     </entry>
     <entry name="showDuckDuckGoChat" type="Bool">
@@ -109,7 +107,6 @@
       <default></default>
     </entry>
     <entry name="customSites" type="String">
-      <label>i18n("List of custom sites")</label>
       <default></default>
     </entry>
     <entry name="keepOpen" type="Bool">
@@ -119,76 +116,67 @@
       <default>false</default>
     </entry>
     <entry name="loadOnStartup" type="Bool">
-      <label>i18n("Load website on Plasma startup")</label>
       <default>false</default>
     </entry>
     <entry name="keepWebEngineAlive" type="Bool">
-      <label>Keep WebEngine in memory after closing for faster reopening</label>
       <default>true</default>
     </entry>
     <entry name="spatialNavigationEnabled" type="Bool">
-      <label>Enable spatial navigation for keyboard-based browsing</label>
       <default>false</default>
     </entry>
     <entry name="javascriptCanPaste" type="Bool">
-      <label>Allow JavaScript to paste from clipboard</label>
       <default>true</default>
     </entry>
     <entry name="javascriptCanOpenWindows" type="Bool">
-      <label>Allow JavaScript to open new windows</label>
       <default>true</default>
     </entry>
     <entry name="javascriptCanAccessClipboard" type="Bool">
-      <label>Allow JavaScript to access clipboard</label>
       <default>true</default>
     </entry>
     <entry name="allowUnknownUrlSchemes" type="Bool">
-      <label>Allow unknown URL schemes</label>
       <default>true</default>
     </entry>
     <entry name="playbackRequiresUserGesture" type="Bool">
-      <label>Require user gesture for media playback</label>
       <default>false</default>
     </entry>
     <entry name="focusOnNavigationEnabled" type="Bool">
-      <label>Enable focus on navigation</label>
       <default>true</default>
     </entry>
     <entry name="notificationsEnabled" type="Bool">
-      <label>Allow notifications from websites</label>
       <default>true</default>
     </entry>
     <entry name="geolocationEnabled" type="Bool">
-      <label>Allow websites to access geolocation</label>
       <default>false</default>
     </entry>
     <entry name="autoHideHeader" type="Bool">
-      <label>Auto-hide header and show on mouse hover</label>
       <default>false</default>
     </entry>
     <entry name="webEngineProfileName" type="String">
-      <label>Storage name used for Qt WebEngine profile</label>
       <default>chat-ai</default>
     </entry>
-    <entry name="enableBlurEffects" type="Bool">
-      <label>Enable blur/glass effects on overlays</label>
-      <default>true</default>
-    </entry>
     <entry name="overlayOpacity" type="Double">
-      <label>Opacity for overlay elements (0.0 to 1.0)</label>
       <default>0.85</default>
     </entry>
     <entry name="enableAnimations" type="Bool">
-      <label>Enable smooth animations</label>
       <default>true</default>
     </entry>
     <entry name="enableTransparency" type="Bool">
-      <label>Enable transparent background with desktop blur behind</label>
       <default>false</default>
     </entry>
     <entry name="backgroundTransparency" type="Double">
-      <label>Background transparency level (0.0 fully transparent to 1.0 opaque)</label>
       <default>0.85</default>
+    </entry>
+    <entry name="headerGradient" type="Bool">
+      <label>Show gradient effect on header</label>
+      <default>false</default>
+    </entry>
+    <entry name="accentBorder" type="Bool">
+      <label>Show accent color border around the widget</label>
+      <default>false</default>
+    </entry>
+    <entry name="accentBorderWidth" type="Int">
+      <label>Accent border width in pixels</label>
+      <default>2</default>
     </entry>
   </group>
 </kcfg>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -16,34 +16,6 @@
       <label>i18n("Icon display mode (0: Favicon, 1: Adaptive, 2: Dark, 3: Light, 4: Outlined, 5: Filled, 6: Colorful)")</label>
       <default>1</default>
     </entry>
-    <entry name="useFilledChatIcon" type="Bool">
-      <label>i18n("Use the filled chat's icon instead of widget icon")</label>
-      <default>false</default>
-    </entry>
-    <entry name="useOutlinedChatIcon" type="Bool">
-      <label>Use the outline chat's icon instead of widget icon</label>
-      <default>false</default>
-    </entry>
-    <entry name="useColorfulChatIcon" type="Bool">
-      <label>Use the colorful chat's icon instead of widget icon</label>
-      <default>false</default>
-    </entry>
-    <entry name="useDefaultIcon" type="Bool">
-      <label>Use the widget's default adaptive icon</label>
-      <default>true</default>
-    </entry>
-    <entry name="useDefaultLightIcon" type="Bool">
-      <label>Use the widget's default light icon</label>
-      <default>false</default>
-    </entry>
-    <entry name="useDefaultDarkIcon" type="Bool">
-      <label>Use the widget's default dark icon</label>
-      <default>false</default>
-    </entry>
-    <entry name="useFavicon" type="Bool">
-      <label>Use website favicon as widget icon</label>
-      <default>false</default>
-    </entry>
     <entry name="favIcon" type="String">
       <label>Base64 encoded favicon from website</label>
       <default></default>
@@ -98,9 +70,6 @@
       <default>false</default>
     </entry>
     <entry name="hideHeader" type="Bool">
-      <default>false</default>
-    </entry>
-    <entry name="hideGoToButton" type="Bool">
       <default>false</default>
     </entry>
     <entry name="hideKeepOpen" type="Bool">
@@ -181,33 +150,9 @@
       <label>Enable focus on navigation</label>
       <default>true</default>
     </entry>
-    <entry name="centerOnScreen" type="Bool">
-      <label>Center window on screen when opened</label>
-      <default>false</default>
-    </entry>
-    <entry name="dialogWidth" type="Int">
-      <label>Last saved dialog width</label>
-      <default>0</default>
-    </entry>
-    <entry name="dialogHeight" type="Int">
-      <label>Last saved dialog height</label>
-      <default>0</default>
-    </entry>
     <entry name="notificationsEnabled" type="Bool">
       <label>Allow notifications from websites</label>
       <default>true</default>
-    </entry>
-    <entry name="notificationFlags" type="Int">
-      <label>Notification display flags</label>
-      <default>0</default>
-    </entry>
-    <entry name="notificationUrgency" type="Int">
-      <label>Notification urgency level</label>
-      <default>1</default>
-    </entry>
-    <entry name="notificationTimeout" type="Int">
-      <label>Notification timeout in milliseconds (0 for no timeout)</label>
-      <default>5000</default>
     </entry>
     <entry name="geolocationEnabled" type="Bool">
       <label>Allow websites to access geolocation</label>
@@ -215,14 +160,6 @@
     </entry>
     <entry name="autoHideHeader" type="Bool">
       <label>Auto-hide header and show on mouse hover</label>
-      <default>false</default>
-    </entry>
-    <entry name="cachePath" type="String">
-      <label>Cache directory path</label>
-      <default></default>
-    </entry>
-    <entry name="clearCacheOnExit" type="Bool">
-      <label>Clear cache when closing</label>
       <default>false</default>
     </entry>
     <entry name="webEngineProfileName" type="String">

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -109,7 +109,7 @@
     <entry name="hideCustomURL" type="Bool">
       <default>false</default>
     </entry>
-    <entry name="hidePrintButton" type="Bool">
+    <entry name="hideAutoHideButton" type="Bool">
       <default>false</default>
     </entry>
     <entry name="hideCloseButton" type="Bool">

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -171,5 +171,9 @@
       <label>Show accent glow around the widget</label>
       <default>false</default>
     </entry>
+    <entry name="spoofChromeBrowser" type="Bool">
+      <label>Disguise as Chrome browser for better site compatibility</label>
+      <default>true</default>
+    </entry>
   </group>
 </kcfg>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -112,9 +112,6 @@
     <entry name="keepOpen" type="Bool">
       <default>false</default>
     </entry>
-    <entry name="pin" type="Bool">
-      <default>false</default>
-    </entry>
     <entry name="loadOnStartup" type="Bool">
       <default>false</default>
     </entry>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -175,5 +175,9 @@
       <label>Disguise as Chrome browser for better site compatibility</label>
       <default>true</default>
     </entry>
+    <entry name="focusMode" type="Bool">
+      <label>Hide sidebars and navigation for a cleaner chat view</label>
+      <default>false</default>
+    </entry>
   </group>
 </kcfg>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -8,6 +8,9 @@
     <entry name="url" type="String">
       <default>https://duckduckgo.com/chat</default>
     </entry>
+    <entry name="lastVisitedUrl" type="String">
+      <default></default>
+    </entry>
     <entry name="icon" type="String">
       <label>i18n("The name of the icon used in the compact representation (e.g. on a small panel).")</label>
       <default></default>
@@ -157,11 +160,12 @@
     <entry name="enableAnimations" type="Bool">
       <default>true</default>
     </entry>
-    <entry name="enableTransparency" type="Bool">
-      <default>false</default>
-    </entry>
     <entry name="backgroundTransparency" type="Double">
       <default>0.85</default>
+    </entry>
+    <entry name="enableBlur" type="Bool">
+      <label>Enable blur effect (desktop + web page backgrounds)</label>
+      <default>true</default>
     </entry>
     <entry name="headerGradient" type="Bool">
       <label>Show gradient effect on header</label>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -170,5 +170,17 @@
       <label>Storage name used for Qt WebEngine profile</label>
       <default>chat-ai</default>
     </entry>
+    <entry name="enableBlurEffects" type="Bool">
+      <label>Enable blur/glass effects on overlays</label>
+      <default>true</default>
+    </entry>
+    <entry name="overlayOpacity" type="Double">
+      <label>Opacity for overlay elements (0.0 to 1.0)</label>
+      <default>0.85</default>
+    </entry>
+    <entry name="enableAnimations" type="Bool">
+      <label>Enable smooth animations</label>
+      <default>true</default>
+    </entry>
   </group>
 </kcfg>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -122,6 +122,10 @@
       <label>i18n("Load website on Plasma startup")</label>
       <default>false</default>
     </entry>
+    <entry name="keepWebEngineAlive" type="Bool">
+      <label>Keep WebEngine in memory after closing for faster reopening</label>
+      <default>true</default>
+    </entry>
     <entry name="spatialNavigationEnabled" type="Bool">
       <label>Enable spatial navigation for keyboard-based browsing</label>
       <default>false</default>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -182,5 +182,13 @@
       <label>Enable smooth animations</label>
       <default>true</default>
     </entry>
+    <entry name="enableTransparency" type="Bool">
+      <label>Enable transparent background with desktop blur behind</label>
+      <default>false</default>
+    </entry>
+    <entry name="backgroundTransparency" type="Double">
+      <label>Background transparency level (0.0 fully transparent to 1.0 opaque)</label>
+      <default>0.85</default>
+    </entry>
   </group>
 </kcfg>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -168,12 +168,8 @@
       <default>false</default>
     </entry>
     <entry name="accentBorder" type="Bool">
-      <label>Show accent color border around the widget</label>
+      <label>Show accent glow around the widget</label>
       <default>false</default>
-    </entry>
-    <entry name="accentBorderWidth" type="Int">
-      <label>Accent border width in pixels</label>
-      <default>2</default>
     </entry>
   </group>
 </kcfg>

--- a/contents/ui/ConfigAppearance.qml
+++ b/contents/ui/ConfigAppearance.qml
@@ -85,6 +85,54 @@ KCM.SimpleKCM {
             Layout.fillWidth: true
         }
 
+        // Transparency section
+        QQC2.Label {
+            Kirigami.FormData.label: i18n("Transparency")
+            font.bold: true
+            Layout.fillWidth: true
+        }
+
+        QQC2.CheckBox {
+            id: enableTransparency
+            text: i18n("Transparent background with desktop blur")
+            checked: plasmoid.configuration.enableTransparency
+            onCheckedChanged: plasmoid.configuration.enableTransparency = checked
+            Layout.fillWidth: true
+        }
+
+        RowLayout {
+            Kirigami.FormData.label: i18n("Background opacity:")
+            Layout.fillWidth: true
+            enabled: enableTransparency.checked
+
+            QQC2.Slider {
+                id: backgroundTransparency
+                from: 0.0
+                to: 0.95
+                stepSize: 0.05
+                value: plasmoid.configuration.backgroundTransparency
+                onMoved: plasmoid.configuration.backgroundTransparency = value
+                Layout.fillWidth: true
+            }
+
+            QQC2.Label {
+                text: Math.round(backgroundTransparency.value * 100) + "%"
+                Layout.minimumWidth: Kirigami.Units.gridUnit * 2
+            }
+        }
+
+        Kirigami.InlineMessage {
+            Layout.fillWidth: true
+            type: Kirigami.MessageType.Information
+            text: i18n("Makes the website background semi-transparent so the desktop blur shows through. Lower values = more transparent. Requires compositor with blur support.")
+            visible: enableTransparency.checked
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Layout.fillWidth: true
+        }
+
         // Header Options section
         QQC2.Label {
             Kirigami.FormData.label: i18n("Header Options")

--- a/contents/ui/ConfigAppearance.qml
+++ b/contents/ui/ConfigAppearance.qml
@@ -52,6 +52,40 @@ KCM.SimpleKCM {
             Layout.fillWidth: true
         }
 
+        QQC2.CheckBox {
+            id: headerGradient
+            text: i18n("Header gradient (accent color tint)")
+            checked: plasmoid.configuration.headerGradient
+            onCheckedChanged: plasmoid.configuration.headerGradient = checked
+            Layout.fillWidth: true
+        }
+
+        QQC2.CheckBox {
+            id: accentBorder
+            text: i18n("Accent color border around widget")
+            checked: plasmoid.configuration.accentBorder
+            onCheckedChanged: plasmoid.configuration.accentBorder = checked
+            Layout.fillWidth: true
+        }
+
+        RowLayout {
+            Kirigami.FormData.label: i18n("Border width:")
+            Layout.fillWidth: true
+            enabled: accentBorder.checked
+
+            QQC2.SpinBox {
+                id: accentBorderWidth
+                from: 1
+                to: 5
+                value: plasmoid.configuration.accentBorderWidth
+                onValueModified: plasmoid.configuration.accentBorderWidth = value
+            }
+
+            QQC2.Label {
+                text: i18n("px")
+            }
+        }
+
         RowLayout {
             Kirigami.FormData.label: i18n("Overlay opacity:")
             Layout.fillWidth: true

--- a/contents/ui/ConfigAppearance.qml
+++ b/contents/ui/ConfigAppearance.qml
@@ -106,6 +106,13 @@ KCM.SimpleKCM {
             }
         }
 
+        Kirigami.InlineMessage {
+            Layout.fillWidth: true
+            type: Kirigami.MessageType.Information
+            text: i18n("Affects the find bar, download bar, and link status bubble that appear over the web content.")
+            visible: true
+        }
+
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
             Layout.fillWidth: true

--- a/contents/ui/ConfigAppearance.qml
+++ b/contents/ui/ConfigAppearance.qml
@@ -88,25 +88,32 @@ KCM.SimpleKCM {
             Layout.fillWidth: true
         }
 
-        // Transparency section
+        // Transparency & Blur section
         QQC2.Label {
-            Kirigami.FormData.label: i18n("Transparency")
+            Kirigami.FormData.label: i18n("Transparency & Blur")
             font.bold: true
             Layout.fillWidth: true
         }
 
         QQC2.CheckBox {
-            id: enableTransparency
-            text: i18n("Transparent background with desktop blur")
-            checked: plasmoid.configuration.enableTransparency
-            onCheckedChanged: plasmoid.configuration.enableTransparency = checked
+            id: enableBlur
+            text: i18n("Enable blur effect")
+            checked: plasmoid.configuration.enableBlur
+            onCheckedChanged: plasmoid.configuration.enableBlur = checked
             Layout.fillWidth: true
+        }
+
+        Kirigami.InlineMessage {
+            Layout.fillWidth: true
+            type: Kirigami.MessageType.Information
+            text: i18n("Blurs the desktop behind the popup and makes web page backgrounds semi-transparent. Requires a compositor with blur support.")
+            visible: enableBlur.checked
         }
 
         RowLayout {
             Kirigami.FormData.label: i18n("Background opacity:")
             Layout.fillWidth: true
-            enabled: enableTransparency.checked
+            enabled: enableBlur.checked
 
             QQC2.Slider {
                 id: backgroundTransparency
@@ -122,13 +129,6 @@ KCM.SimpleKCM {
                 text: Math.round(backgroundTransparency.value * 100) + "%"
                 Layout.minimumWidth: Kirigami.Units.gridUnit * 2
             }
-        }
-
-        Kirigami.InlineMessage {
-            Layout.fillWidth: true
-            type: Kirigami.MessageType.Information
-            text: i18n("Makes the website background semi-transparent so the desktop blur shows through. Lower values = more transparent. Requires compositor with blur support.")
-            visible: enableTransparency.checked
         }
 
         Kirigami.Separator {

--- a/contents/ui/ConfigAppearance.qml
+++ b/contents/ui/ConfigAppearance.qml
@@ -45,14 +45,6 @@ KCM.SimpleKCM {
         }
 
         QQC2.CheckBox {
-            id: enableBlurEffects
-            text: i18n("Blur/glass effects on overlays")
-            checked: plasmoid.configuration.enableBlurEffects
-            onCheckedChanged: plasmoid.configuration.enableBlurEffects = checked
-            Layout.fillWidth: true
-        }
-
-        QQC2.CheckBox {
             id: enableAnimations
             text: i18n("Smooth animations")
             checked: plasmoid.configuration.enableAnimations

--- a/contents/ui/ConfigAppearance.qml
+++ b/contents/ui/ConfigAppearance.qml
@@ -83,11 +83,11 @@ KCM.SimpleKCM {
         }
 
         QQC2.CheckBox {
-            id: hidePrintButton
+            id: hideAutoHideButton
 
             text: i18n("Hide Auto-Hide button")
-            checked: plasmoid.configuration.hidePrintButton
-            onCheckedChanged: plasmoid.configuration.hidePrintButton = checked
+            checked: plasmoid.configuration.hideAutoHideButton
+            onCheckedChanged: plasmoid.configuration.hideAutoHideButton = checked
             Layout.fillWidth: true
         }
 

--- a/contents/ui/ConfigAppearance.qml
+++ b/contents/ui/ConfigAppearance.qml
@@ -110,26 +110,6 @@ KCM.SimpleKCM {
             visible: enableBlur.checked
         }
 
-        RowLayout {
-            Kirigami.FormData.label: i18n("Background opacity:")
-            Layout.fillWidth: true
-            enabled: enableBlur.checked
-
-            QQC2.Slider {
-                id: backgroundTransparency
-                from: 0.0
-                to: 0.95
-                stepSize: 0.05
-                value: plasmoid.configuration.backgroundTransparency
-                onMoved: plasmoid.configuration.backgroundTransparency = value
-                Layout.fillWidth: true
-            }
-
-            QQC2.Label {
-                text: Math.round(backgroundTransparency.value * 100) + "%"
-                Layout.minimumWidth: Kirigami.Units.gridUnit * 2
-            }
-        }
 
         Kirigami.Separator {
             Kirigami.FormData.isSection: true

--- a/contents/ui/ConfigAppearance.qml
+++ b/contents/ui/ConfigAppearance.qml
@@ -31,7 +31,55 @@ KCM.SimpleKCM {
             Layout.fillWidth: true
         }
 
-        // Separator between icon and header sections
+        // Separator between icon and effects sections
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Layout.fillWidth: true
+        }
+
+        // Visual Effects section
+        QQC2.Label {
+            Kirigami.FormData.label: i18n("Visual Effects")
+            font.bold: true
+            Layout.fillWidth: true
+        }
+
+        QQC2.CheckBox {
+            id: enableBlurEffects
+            text: i18n("Blur/glass effects on overlays")
+            checked: plasmoid.configuration.enableBlurEffects
+            onCheckedChanged: plasmoid.configuration.enableBlurEffects = checked
+            Layout.fillWidth: true
+        }
+
+        QQC2.CheckBox {
+            id: enableAnimations
+            text: i18n("Smooth animations")
+            checked: plasmoid.configuration.enableAnimations
+            onCheckedChanged: plasmoid.configuration.enableAnimations = checked
+            Layout.fillWidth: true
+        }
+
+        RowLayout {
+            Kirigami.FormData.label: i18n("Overlay opacity:")
+            Layout.fillWidth: true
+
+            QQC2.Slider {
+                id: overlayOpacity
+                from: 0.3
+                to: 1.0
+                stepSize: 0.05
+                value: plasmoid.configuration.overlayOpacity
+                onMoved: plasmoid.configuration.overlayOpacity = value
+                Layout.fillWidth: true
+            }
+
+            QQC2.Label {
+                text: Math.round(overlayOpacity.value * 100) + "%"
+                Layout.minimumWidth: Kirigami.Units.gridUnit * 2
+            }
+        }
+
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
             Layout.fillWidth: true

--- a/contents/ui/ConfigAppearance.qml
+++ b/contents/ui/ConfigAppearance.qml
@@ -140,7 +140,7 @@ KCM.SimpleKCM {
         Kirigami.InlineMessage {
             Layout.fillWidth: true
             text: i18n("You can still use the Go back to... and Keep open actions by right-clicking the widget icon.")
-            visible: hideHeader.checked || hideGoToButton.checked || hideKeepOpen.checked
+            visible: hideHeader.checked || hideKeepOpen.checked
         }
     }
 }

--- a/contents/ui/ConfigAppearance.qml
+++ b/contents/ui/ConfigAppearance.qml
@@ -68,6 +68,21 @@ KCM.SimpleKCM {
             Layout.fillWidth: true
         }
 
+        QQC2.CheckBox {
+            id: focusMode
+            text: i18n("Focus mode (hide sidebars and site navigation)")
+            checked: plasmoid.configuration.focusMode
+            onCheckedChanged: plasmoid.configuration.focusMode = checked
+            Layout.fillWidth: true
+        }
+
+        Kirigami.InlineMessage {
+            Layout.fillWidth: true
+            type: Kirigami.MessageType.Information
+            text: i18n("Hides sidebars, headers, and non-essential UI from supported chat services (ChatGPT, Claude, Gemini, DuckDuckGo, DeepSeek, Copilot). May break if sites update their layout.")
+            visible: focusMode.checked
+        }
+
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
             Layout.fillWidth: true

--- a/contents/ui/ConfigAppearance.qml
+++ b/contents/ui/ConfigAppearance.qml
@@ -61,56 +61,11 @@ KCM.SimpleKCM {
         }
 
         QQC2.CheckBox {
-            id: accentBorder
-            text: i18n("Accent color border around widget")
+            id: accentGlow
+            text: i18n("Accent glow around widget")
             checked: plasmoid.configuration.accentBorder
             onCheckedChanged: plasmoid.configuration.accentBorder = checked
             Layout.fillWidth: true
-        }
-
-        RowLayout {
-            Kirigami.FormData.label: i18n("Border width:")
-            Layout.fillWidth: true
-            enabled: accentBorder.checked
-
-            QQC2.SpinBox {
-                id: accentBorderWidth
-                from: 1
-                to: 5
-                value: plasmoid.configuration.accentBorderWidth
-                onValueModified: plasmoid.configuration.accentBorderWidth = value
-            }
-
-            QQC2.Label {
-                text: i18n("px")
-            }
-        }
-
-        RowLayout {
-            Kirigami.FormData.label: i18n("Overlay opacity:")
-            Layout.fillWidth: true
-
-            QQC2.Slider {
-                id: overlayOpacity
-                from: 0.3
-                to: 1.0
-                stepSize: 0.05
-                value: plasmoid.configuration.overlayOpacity
-                onMoved: plasmoid.configuration.overlayOpacity = value
-                Layout.fillWidth: true
-            }
-
-            QQC2.Label {
-                text: Math.round(overlayOpacity.value * 100) + "%"
-                Layout.minimumWidth: Kirigami.Units.gridUnit * 2
-            }
-        }
-
-        Kirigami.InlineMessage {
-            Layout.fillWidth: true
-            type: Kirigami.MessageType.Information
-            text: i18n("Affects the find bar, download bar, and link status bubble that appear over the web content.")
-            visible: true
         }
 
         Kirigami.Separator {

--- a/contents/ui/ConfigAppearance.qml
+++ b/contents/ui/ConfigAppearance.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls as QQC2
 import QtQuick.Layouts
 import org.kde.kcmutils as KCM
-import org.kde.kirigami 2.20 as Kirigami
+import org.kde.kirigami as Kirigami
 
 KCM.SimpleKCM {
     property alias cfg_iconMode: iconMode.currentIndex

--- a/contents/ui/ConfigGeneral.qml
+++ b/contents/ui/ConfigGeneral.qml
@@ -83,10 +83,7 @@ KCM.SimpleKCM {
         id: scrollView
 
         anchors.fill: parent
-        // Enable vertical scrollbar
-        Component.onCompleted: {
-            QQC2.ScrollBar.vertical.policy = QQC2.ScrollBar.AlwaysOn;
-        }
+        QQC2.ScrollBar.vertical.policy: QQC2.ScrollBar.AsNeeded
 
         Item {
             width: scrollView.width

--- a/contents/ui/ConfigGeneral.qml
+++ b/contents/ui/ConfigGeneral.qml
@@ -400,6 +400,21 @@ Action=Popup`
                 }
 
                 QQC2.CheckBox {
+                    id: spoofChromeBrowser
+                    text: i18n("Disguise as Chrome (better login compatibility)")
+                    checked: plasmoid.configuration.spoofChromeBrowser
+                    onCheckedChanged: plasmoid.configuration.spoofChromeBrowser = checked
+                    Layout.fillWidth: true
+                }
+
+                Kirigami.InlineMessage {
+                    Layout.fillWidth: true
+                    type: Kirigami.MessageType.Information
+                    text: i18n("Spoofs browser identity so login pages (Google, Claude, etc.) accept this widget as a regular Chrome browser. Recommended to keep enabled.")
+                    visible: spoofChromeBrowser.checked
+                }
+
+                QQC2.CheckBox {
                     id: spatialNavigationEnabled
                     text: i18n("Enable spatial navigation")
                     checked: plasmoid.configuration.spatialNavigationEnabled

--- a/contents/ui/ConfigGeneral.qml
+++ b/contents/ui/ConfigGeneral.qml
@@ -321,6 +321,15 @@ KCM.SimpleKCM {
                     Layout.fillWidth: true
                 }
 
+                QQC2.CheckBox {
+                    id: keepWebEngineAlive
+
+                    text: i18n("Keep in memory after closing (faster reopen)")
+                    checked: plasmoid.configuration.keepWebEngineAlive
+                    onCheckedChanged: plasmoid.configuration.keepWebEngineAlive = checked
+                    Layout.fillWidth: true
+                }
+
                 // Media permissions options
                 QQC2.CheckBox {
                     id: notificationsEnabled

--- a/contents/ui/ConfigGeneral.qml
+++ b/contents/ui/ConfigGeneral.qml
@@ -1,11 +1,11 @@
+import QtCore
 import QtQuick
 import QtQuick.Controls as QQC2
 import QtQuick.Dialogs
 import QtQuick.Layouts
 import org.kde.kcmutils as KCM
-import org.kde.kirigami 2.20 as Kirigami
+import org.kde.kirigami as Kirigami
 import org.kde.plasma.components as PlasmaComponents3
-import Qt.labs.platform 1.1
 import QtWebEngine
 
 // Main configuration component for general settings
@@ -273,7 +273,7 @@ KCM.SimpleKCM {
 
                                         PlasmaComponents3.Label {
                                             text: model.siteData.split("|")[1]
-                                            font.pointSize: theme.smallestFont.pointSize
+                                            font.pointSize: Kirigami.Theme.smallFont.pointSize
                                             opacity: 0.7
                                             Layout.fillWidth: true
                                             wrapMode: Text.WordWrap

--- a/contents/ui/ContextMenu.qml
+++ b/contents/ui/ContextMenu.qml
@@ -1,0 +1,65 @@
+import QtQuick
+import org.kde.plasma.components as PlasmaComponents3
+
+PlasmaComponents3.Menu {
+    id: contextMenu
+
+    property bool canGoBack: false
+    property bool canGoForward: false
+    property string link: ""
+
+    signal backRequested()
+    signal forwardRequested()
+    signal reloadRequested()
+    signal saveAsPdfRequested()
+    signal saveAsMHTMLRequested()
+    signal copyLinkRequested()
+
+    PlasmaComponents3.MenuItem {
+        text: i18n("Back")
+        icon.name: "go-previous"
+        enabled: contextMenu.canGoBack
+        onTriggered: contextMenu.backRequested()
+    }
+
+    PlasmaComponents3.MenuItem {
+        text: i18n("Forward")
+        icon.name: "go-next"
+        enabled: contextMenu.canGoForward
+        onTriggered: contextMenu.forwardRequested()
+    }
+
+    PlasmaComponents3.MenuItem {
+        text: i18n("Reload")
+        icon.name: "view-refresh"
+        onTriggered: contextMenu.reloadRequested()
+    }
+
+    PlasmaComponents3.MenuItem {
+        text: i18n("Save as PDF")
+        icon.name: "document-save-as"
+        visible: !contextMenu.link
+        onTriggered: contextMenu.saveAsPdfRequested()
+    }
+
+    PlasmaComponents3.MenuItem {
+        text: i18n("Save as MHTML")
+        icon.name: "document-save"
+        visible: !contextMenu.link
+        onTriggered: contextMenu.saveAsMHTMLRequested()
+    }
+
+    PlasmaComponents3.MenuItem {
+        text: i18n("Open Link in Browser")
+        icon.name: "internet-web-browser"
+        visible: contextMenu.link !== ""
+        onTriggered: Qt.openUrlExternally(contextMenu.link)
+    }
+
+    PlasmaComponents3.MenuItem {
+        text: i18n("Copy Link Address")
+        icon.name: "edit-copy"
+        visible: contextMenu.link !== ""
+        onTriggered: contextMenu.copyLinkRequested()
+    }
+}

--- a/contents/ui/DownloadBar.qml
+++ b/contents/ui/DownloadBar.qml
@@ -37,19 +37,19 @@ Column {
                 PlasmaComponents3.Label {
                     text: {
                         if (model.state === WebEngineDownloadRequest.DownloadCompleted) {
-                            return model.fileName + " - Completed";
+                            return i18n("%1 - Completed", model.fileName);
                         }
                         if (model.isPdfExport) {
-                            return model.fileName + " - Saving PDF...";
+                            return i18n("%1 - Saving PDF...", model.fileName);
                         }
                         let progress = Math.round((model.progress || 0) * 100);
                         let size = "";
                         if (model.totalBytes > 0) {
                             let received = (model.receivedBytes / 1024 / 1024).toFixed(1);
                             let total = (model.totalBytes / 1024 / 1024).toFixed(1);
-                            size = ` (${received}/${total} MB)`;
+                            size = i18n(" (%1/%2 MB)", received, total);
                         }
-                        return model.fileName + " - " + progress + "%" + size;
+                        return i18n("%1 - %2%", model.fileName, progress) + size;
                     }
                     Layout.fillWidth: true
                     elide: Text.ElideMiddle

--- a/contents/ui/DownloadBar.qml
+++ b/contents/ui/DownloadBar.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Effects
 import QtQuick.Layouts
 import QtWebEngine
 import org.kde.plasma.components as PlasmaComponents3
@@ -11,9 +10,7 @@ Column {
 
     property var downloadsModel: null
     property var downloadCacheRef: ({})
-    readonly property bool blurEnabled: plasmoid.configuration.enableBlurEffects
     readonly property real overlayOpacity: plasmoid.configuration.overlayOpacity
-    readonly property bool animEnabled: plasmoid.configuration.enableAnimations
 
     visible: downloadsModel !== null && downloadsModel.count > 0
     spacing: 4
@@ -25,25 +22,12 @@ Column {
     Repeater {
         model: downloadsBarRoot.downloadsModel
 
-        delegate: Item {
+        delegate: Rectangle {
             width: parent.width
             height: 40
-
-            Rectangle {
-                id: dlBg
-                anchors.fill: parent
-                color: Kirigami.Theme.backgroundColor
-                opacity: downloadsBarRoot.blurEnabled ? downloadsBarRoot.overlayOpacity : 0.9
-                radius: Kirigami.Units.smallSpacing
-            }
-
-            MultiEffect {
-                source: dlBg
-                anchors.fill: dlBg
-                blurEnabled: downloadsBarRoot.blurEnabled
-                blur: 1.0
-                blurMax: 32
-            }
+            color: Kirigami.Theme.backgroundColor
+            opacity: downloadsBarRoot.overlayOpacity
+            radius: Kirigami.Units.smallSpacing
 
             RowLayout {
                 anchors.fill: parent

--- a/contents/ui/DownloadBar.qml
+++ b/contents/ui/DownloadBar.qml
@@ -1,14 +1,19 @@
 import QtQuick
+import QtQuick.Effects
 import QtQuick.Layouts
 import QtWebEngine
 import org.kde.plasma.components as PlasmaComponents3
 import org.kde.kirigami as Kirigami
+import org.kde.plasma.plasmoid
 
 Column {
     id: downloadsBarRoot
 
     property var downloadsModel: null
     property var downloadCacheRef: ({})
+    readonly property bool blurEnabled: plasmoid.configuration.enableBlurEffects
+    readonly property real overlayOpacity: plasmoid.configuration.overlayOpacity
+    readonly property bool animEnabled: plasmoid.configuration.enableAnimations
 
     visible: downloadsModel !== null && downloadsModel.count > 0
     spacing: 4
@@ -20,11 +25,25 @@ Column {
     Repeater {
         model: downloadsBarRoot.downloadsModel
 
-        delegate: Rectangle {
+        delegate: Item {
             width: parent.width
             height: 40
-            color: Kirigami.Theme.backgroundColor
-            opacity: 0.9
+
+            Rectangle {
+                id: dlBg
+                anchors.fill: parent
+                color: Kirigami.Theme.backgroundColor
+                opacity: downloadsBarRoot.blurEnabled ? downloadsBarRoot.overlayOpacity : 0.9
+                radius: Kirigami.Units.smallSpacing
+            }
+
+            MultiEffect {
+                source: dlBg
+                anchors.fill: dlBg
+                blurEnabled: downloadsBarRoot.blurEnabled
+                blur: 1.0
+                blurMax: 32
+            }
 
             RowLayout {
                 anchors.fill: parent

--- a/contents/ui/DownloadBar.qml
+++ b/contents/ui/DownloadBar.qml
@@ -1,0 +1,120 @@
+import QtQuick
+import QtQuick.Layouts
+import QtWebEngine
+import org.kde.plasma.components as PlasmaComponents3
+import org.kde.kirigami as Kirigami
+
+Column {
+    id: downloadsBarRoot
+
+    property var downloadsModel: null
+    property var downloadCacheRef: ({})
+
+    visible: downloadsModel !== null && downloadsModel.count > 0
+    spacing: 4
+
+    function getOpenPath(path) {
+        return path.replace(/^file:\/+/, '').replace(/^\/+/, '/');
+    }
+
+    Repeater {
+        model: downloadsBarRoot.downloadsModel
+
+        delegate: Rectangle {
+            width: parent.width
+            height: 40
+            color: Kirigami.Theme.backgroundColor
+            opacity: 0.9
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.margins: 8
+                spacing: 8
+
+                PlasmaComponents3.Label {
+                    text: {
+                        if (model.state === WebEngineDownloadRequest.DownloadCompleted) {
+                            return model.fileName + " - Completed";
+                        }
+                        if (model.isPdfExport) {
+                            return model.fileName + " - Saving PDF...";
+                        }
+                        let progress = Math.round((model.progress || 0) * 100);
+                        let size = "";
+                        if (model.totalBytes > 0) {
+                            let received = (model.receivedBytes / 1024 / 1024).toFixed(1);
+                            let total = (model.totalBytes / 1024 / 1024).toFixed(1);
+                            size = ` (${received}/${total} MB)`;
+                        }
+                        return model.fileName + " - " + progress + "%" + size;
+                    }
+                    Layout.fillWidth: true
+                    elide: Text.ElideMiddle
+                }
+
+                PlasmaComponents3.ProgressBar {
+                    Layout.fillWidth: true
+                    indeterminate: model.isPdfExport
+                    from: 0
+                    to: 1
+                    value: model.progress || 0
+                    visible: model.state === WebEngineDownloadRequest.DownloadInProgress
+                }
+
+                RowLayout {
+                    visible: model.state === WebEngineDownloadRequest.DownloadCompleted
+                    spacing: 4
+
+                    PlasmaComponents3.Button {
+                        icon.name: "document-open"
+                        PlasmaComponents3.ToolTip.text: i18n("Open file")
+                        PlasmaComponents3.ToolTip.visible: hovered
+                        onClicked: {
+                            if (model.fullPath) {
+                                Qt.openUrlExternally(downloadsBarRoot.getOpenPath(model.fullPath));
+                            }
+                        }
+                    }
+
+                    PlasmaComponents3.Button {
+                        icon.name: "folder-open"
+                        PlasmaComponents3.ToolTip.text: i18n("Open folder")
+                        PlasmaComponents3.ToolTip.visible: hovered
+                        onClicked: {
+                            if (model.fullPath) {
+                                let dirPath = model.fullPath.substring(0, model.fullPath.lastIndexOf("/"));
+                                Qt.openUrlExternally(downloadsBarRoot.getOpenPath(dirPath));
+                            }
+                        }
+                    }
+
+                    PlasmaComponents3.Button {
+                        icon.name: "dialog-close"
+                        PlasmaComponents3.ToolTip.text: i18n("Close")
+                        PlasmaComponents3.ToolTip.visible: hovered
+                        onClicked: {
+                            downloadsBarRoot.downloadsModel.remove(model.index);
+                        }
+                    }
+                }
+
+                PlasmaComponents3.Button {
+                    icon.name: "dialog-cancel"
+                    visible: model.state === WebEngineDownloadRequest.DownloadInProgress && !model.isPdfExport
+                    PlasmaComponents3.ToolTip.text: i18n("Cancel")
+                    PlasmaComponents3.ToolTip.visible: hovered
+                    onClicked: {
+                        let downloadData = downloadsBarRoot.downloadCacheRef[model.downloadId];
+                        if (downloadData && downloadData.download) {
+                            downloadData.download.receivedBytesChanged.disconnect(downloadData.bytesConnection);
+                            downloadData.download.stateChanged.disconnect(downloadData.stateConnection);
+                            downloadData.download.cancel();
+                            delete downloadsBarRoot.downloadCacheRef[model.downloadId];
+                            downloadsBarRoot.downloadsModel.remove(index);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/contents/ui/FindBar.qml
+++ b/contents/ui/FindBar.qml
@@ -1,12 +1,17 @@
 import QtQuick
+import QtQuick.Effects
 import QtQuick.Layouts
 import org.kde.plasma.components as PlasmaComponents3
 import org.kde.kirigami as Kirigami
+import org.kde.plasma.plasmoid
 
-Rectangle {
+Item {
     id: findBarRoot
 
     property bool barVisible: false
+    readonly property bool blurEnabled: plasmoid.configuration.enableBlurEffects
+    readonly property bool animEnabled: plasmoid.configuration.enableAnimations
+    readonly property real overlayOpacity: plasmoid.configuration.overlayOpacity
 
     signal findRequested(string text)
     signal findPreviousRequested(string text)
@@ -14,12 +19,28 @@ Rectangle {
 
     visible: barVisible
     height: visible ? findBarRow.height + Kirigami.Units.smallSpacing * 2 : 0
-    color: Kirigami.Theme.backgroundColor
     z: 5
 
     function focusField() {
         findField.forceActiveFocus();
         findField.selectAll();
+    }
+
+    // Background with blur
+    Rectangle {
+        id: findBarBg
+        anchors.fill: parent
+        color: Kirigami.Theme.backgroundColor
+        opacity: findBarRoot.blurEnabled ? findBarRoot.overlayOpacity : 1.0
+        radius: Kirigami.Units.smallSpacing
+    }
+
+    MultiEffect {
+        source: findBarBg
+        anchors.fill: findBarBg
+        blurEnabled: findBarRoot.blurEnabled
+        blur: 1.0
+        blurMax: 32
     }
 
     RowLayout {
@@ -80,9 +101,17 @@ Rectangle {
     }
 
     Behavior on height {
+        enabled: findBarRoot.animEnabled
         NumberAnimation {
             duration: Kirigami.Units.shortDuration
             easing.type: Easing.InOutQuad
+        }
+    }
+
+    Behavior on opacity {
+        enabled: findBarRoot.animEnabled
+        NumberAnimation {
+            duration: Kirigami.Units.shortDuration
         }
     }
 }

--- a/contents/ui/FindBar.qml
+++ b/contents/ui/FindBar.qml
@@ -1,15 +1,13 @@
 import QtQuick
-import QtQuick.Effects
 import QtQuick.Layouts
 import org.kde.plasma.components as PlasmaComponents3
 import org.kde.kirigami as Kirigami
 import org.kde.plasma.plasmoid
 
-Item {
+Rectangle {
     id: findBarRoot
 
     property bool barVisible: false
-    readonly property bool blurEnabled: plasmoid.configuration.enableBlurEffects
     readonly property bool animEnabled: plasmoid.configuration.enableAnimations
     readonly property real overlayOpacity: plasmoid.configuration.overlayOpacity
 
@@ -19,28 +17,14 @@ Item {
 
     visible: barVisible
     height: visible ? findBarRow.height + Kirigami.Units.smallSpacing * 2 : 0
+    color: Kirigami.Theme.backgroundColor
+    opacity: overlayOpacity
+    radius: Kirigami.Units.smallSpacing
     z: 5
 
     function focusField() {
         findField.forceActiveFocus();
         findField.selectAll();
-    }
-
-    // Background with blur
-    Rectangle {
-        id: findBarBg
-        anchors.fill: parent
-        color: Kirigami.Theme.backgroundColor
-        opacity: findBarRoot.blurEnabled ? findBarRoot.overlayOpacity : 1.0
-        radius: Kirigami.Units.smallSpacing
-    }
-
-    MultiEffect {
-        source: findBarBg
-        anchors.fill: findBarBg
-        blurEnabled: findBarRoot.blurEnabled
-        blur: 1.0
-        blurMax: 32
     }
 
     RowLayout {
@@ -105,13 +89,6 @@ Item {
         NumberAnimation {
             duration: Kirigami.Units.shortDuration
             easing.type: Easing.InOutQuad
-        }
-    }
-
-    Behavior on opacity {
-        enabled: findBarRoot.animEnabled
-        NumberAnimation {
-            duration: Kirigami.Units.shortDuration
         }
     }
 }

--- a/contents/ui/FindBar.qml
+++ b/contents/ui/FindBar.qml
@@ -1,0 +1,88 @@
+import QtQuick
+import QtQuick.Layouts
+import org.kde.plasma.components as PlasmaComponents3
+import org.kde.kirigami as Kirigami
+
+Rectangle {
+    id: findBarRoot
+
+    property bool barVisible: false
+
+    signal findRequested(string text)
+    signal findPreviousRequested(string text)
+    signal closed()
+
+    visible: barVisible
+    height: visible ? findBarRow.height + Kirigami.Units.smallSpacing * 2 : 0
+    color: Kirigami.Theme.backgroundColor
+    z: 5
+
+    function focusField() {
+        findField.forceActiveFocus();
+        findField.selectAll();
+    }
+
+    RowLayout {
+        id: findBarRow
+
+        anchors {
+            left: parent.left
+            right: parent.right
+            top: parent.top
+            margins: Kirigami.Units.smallSpacing
+        }
+
+        spacing: Kirigami.Units.smallSpacing
+
+        PlasmaComponents3.TextField {
+            id: findField
+
+            Layout.fillWidth: true
+
+            placeholderText: i18n("Find in page...")
+            onTextChanged: if (text)
+                findBarRoot.findRequested(text)
+            onAccepted: findBarRoot.findRequested(text)
+            Keys.onEscapePressed: findBarRoot.closed()
+
+            Component.onCompleted: {
+                if (findBarRoot.barVisible) {
+                    forceActiveFocus();
+                }
+            }
+        }
+
+        PlasmaComponents3.Button {
+            icon.name: "go-up"
+            display: PlasmaComponents3.AbstractButton.IconOnly
+            onClicked: findBarRoot.findPreviousRequested(findField.text)
+            PlasmaComponents3.ToolTip.text: i18n("Find previous")
+            PlasmaComponents3.ToolTip.visible: hovered
+            enabled: findField.text !== ""
+        }
+
+        PlasmaComponents3.Button {
+            icon.name: "go-down"
+            display: PlasmaComponents3.AbstractButton.IconOnly
+            onClicked: findBarRoot.findRequested(findField.text)
+            PlasmaComponents3.ToolTip.text: i18n("Find next")
+            PlasmaComponents3.ToolTip.visible: hovered
+            enabled: findField.text !== ""
+        }
+
+        PlasmaComponents3.Button {
+            icon.name: "dialog-close"
+            display: PlasmaComponents3.AbstractButton.IconOnly
+            PlasmaComponents3.ToolTip.text: i18n("Close")
+            PlasmaComponents3.ToolTip.visible: hovered
+            onClicked: findBarRoot.closed()
+        }
+    }
+
+    Behavior on height {
+        NumberAnimation {
+            duration: Kirigami.Units.shortDuration
+            easing.type: Easing.InOutQuad
+        }
+    }
+}

--- a/contents/ui/Header.qml
+++ b/contents/ui/Header.qml
@@ -135,7 +135,7 @@ RowLayout {
     // Auto-Hide Button
     PlasmaComponents3.Button {
         id: autoHideButton
-        visible: !plasmoid.configuration.hidePrintButton
+        visible: !plasmoid.configuration.hideAutoHideButton
         icon.name: plasmoid.configuration.autoHideHeader ? "view-visible" : "view-hidden"
         display: PlasmaComponents3.AbstractButton.IconOnly
         checkable: true

--- a/contents/ui/Header.qml
+++ b/contents/ui/Header.qml
@@ -301,57 +301,18 @@ RowLayout {
         restoreMode: Binding.RestoreBinding
     }
 
-    // Configuration change handlers
-    // Updates model list when chat service visibility settings change
-    Connections {
-        target: plasmoid.configuration
-        function onCustomSitesChanged() {
-            renderChatModel();
+    // Reactive snapshot of all model visibility states.
+    // QML automatically re-evaluates this binding whenever any accessed
+    // configuration property changes, so adding a new service to `models`
+    // requires no additional signal handler here.
+    readonly property var modelVisibilityState: {
+        const snapshot = [plasmoid.configuration.customSites];
+        if (models) {
+            for (let i = 0; i < models.length; i++) {
+                snapshot.push(plasmoid.configuration[models[i].prop]);
+            }
         }
-        function onShowT3ChatChanged() {
-            renderChatModel();
-        }
-        function onShowDuckDuckGoChatChanged() {
-            renderChatModel();
-        }
-        function onShowChatGPTChanged() {
-            renderChatModel();
-        }
-        function onShowHugginChatChanged() {
-            renderChatModel();
-        }
-        function onShowGoogleGeminiChanged() {
-            renderChatModel();
-        }
-        function onShowYouChanged() {
-            renderChatModel();
-        }
-        function onShowPerplexityChanged() {
-            renderChatModel();
-        }
-        function onShowLobeChatChanged() {
-            renderChatModel();
-        }
-        function onShowBigAGIChanged() {
-            renderChatModel();
-        }
-        function onShowBlackBoxChanged() {
-            renderChatModel();
-        }
-        function onShowBingCopilotChanged() {
-            renderChatModel();
-        }
-        function onShowClaudeChanged() {
-            renderChatModel();
-        }
-        function onShowDeepSeekChanged() {
-            renderChatModel();
-        }
-        function onShowMetaAIChanged() {
-            renderChatModel();
-        }
-        function onShowGrokChanged() {
-            renderChatModel();
-        }
+        return snapshot;
     }
+    onModelVisibilityStateChanged: renderChatModel()
 }

--- a/contents/ui/Header.qml
+++ b/contents/ui/Header.qml
@@ -11,6 +11,20 @@ Item {
     Layout.fillWidth: true
     implicitHeight: headerRow.implicitHeight
 
+    // Signals for communication with parent components
+    signal goBackToHomePage
+    signal closeWebViewRequested
+    signal reloadPageRequested
+    signal navigateBackRequested
+    signal navigateForwardRequested
+    signal printPageRequested
+    signal toggleSearchRequested
+
+    // Properties for managing component state
+    property var closeWebViewCallback: undefined
+    property var models
+    property var webview: (parent && parent.webviewRoot) ? parent.webviewRoot.webview : null
+
     // Header gradient background
     Rectangle {
         anchors.fill: parent
@@ -25,21 +39,6 @@ Item {
     RowLayout {
         id: headerRow
         anchors.fill: parent
-
-    // Signals for communication with parent components
-    signal goBackToHomePage
-    signal closeWebViewRequested
-    signal reloadPageRequested
-    signal navigateBackRequested
-    signal navigateForwardRequested
-    signal printPageRequested
-    signal toggleSearchRequested
-
-    // Properties for managing component state
-    property var closeWebViewCallback: undefined    // Callback function for closing webview
-    property var models                            // Available chat models
-    property bool showCustomURLInput: false        // Toggle between URL selector and custom URL input
-    property var webview: (parent && parent.webviewRoot) ? parent.webviewRoot.webview : null
 
     // Navigation buttons
     PlasmaComponents3.Button {

--- a/contents/ui/Header.qml
+++ b/contents/ui/Header.qml
@@ -290,10 +290,9 @@ Item {
             return;
         }
 
-        const selectedText = urlComboBox.currentValue;
+        const selectedText = urlComboBox.currentText;
         if (!selectedText)
             return;
-        urlComboBox.displayText = selectedText;
 
         const selectedModel = models.find(model => !model.prop.startsWith("showCustom_") && model.text === selectedText);
         if (selectedModel) {
@@ -307,13 +306,6 @@ Item {
             plasmoid.configuration.url = customSite.split('|')[1];
             goBackToHomePage();
         }
-    }
-
-    Binding {
-        target: root
-        property: "hideOnWindowDeactivate"
-        value: !plasmoid.configuration.pin
-        restoreMode: Binding.RestoreBinding
     }
 
     // Reactive snapshot of all model visibility states.

--- a/contents/ui/Header.qml
+++ b/contents/ui/Header.qml
@@ -25,6 +25,76 @@ Item {
     property var models
     property var webview: (parent && parent.webviewRoot) ? parent.webviewRoot.webview : null
 
+    // Helper Functions
+    function renderChatModel() {
+        const chatModel = models.filter(model => !model.prop.startsWith("showCustom_") && plasmoid.configuration[model.prop]).map(model => model.text)
+        .concat((plasmoid.configuration.customSites || "").split(',').filter(site => site?.includes('|')).map(site => site.split('|')[0])).concat([i18n("Custom URL...")]);
+
+        urlComboBox.model = chatModel;
+
+        const currentUrl = plasmoid.configuration.url;
+        const currentModel = models.find(model => !model.prop.startsWith("showCustom_") && model.url === currentUrl);
+
+        if (currentModel) {
+            const index = chatModel.indexOf(currentModel.text);
+            urlComboBox.currentIndex = index;
+            urlComboBox.editable = false;
+        } else {
+            const customSite = (plasmoid.configuration.customSites || "").split(',').find(site => site?.includes('|') && site.split('|')[1] === currentUrl);
+            if (customSite) {
+                const siteName = customSite.split('|')[0];
+                const index = chatModel.indexOf(siteName);
+                urlComboBox.currentIndex = index;
+                urlComboBox.editable = false;
+            } else {
+                urlComboBox.currentIndex = chatModel.length - 1;
+                urlComboBox.customUrlText = currentUrl;
+                urlComboBox.editText = currentUrl;
+                urlComboBox.editable = true;
+            }
+        }
+    }
+
+    function handleModelSelection() {
+        if (urlComboBox.currentIndex === urlComboBox.count - 1) {
+            let url = urlComboBox.editText;
+            if (url) {
+                plasmoid.configuration.url = url.match(/^https?:\/\//) ? url : "https://" + url;
+                goBackToHomePage();
+            }
+            return;
+        }
+
+        const selectedText = urlComboBox.currentText;
+        if (!selectedText)
+            return;
+
+        const selectedModel = models.find(model => !model.prop.startsWith("showCustom_") && model.text === selectedText);
+        if (selectedModel) {
+            plasmoid.configuration.url = selectedModel.url;
+            goBackToHomePage();
+            return;
+        }
+
+        const customSite = (plasmoid.configuration.customSites || "").split(',').find(site => site?.split('|')[0] === selectedText);
+        if (customSite) {
+            plasmoid.configuration.url = customSite.split('|')[1];
+            goBackToHomePage();
+        }
+    }
+
+    // Reactive snapshot — re-renders when any service toggle changes
+    readonly property var modelVisibilityState: {
+        const snapshot = [plasmoid.configuration.customSites];
+        if (models) {
+            for (let i = 0; i < models.length; i++) {
+                snapshot.push(plasmoid.configuration[models[i].prop]);
+            }
+        }
+        return snapshot;
+    }
+    onModelVisibilityStateChanged: renderChatModel()
+
     // Header gradient background
     Rectangle {
         anchors.fill: parent
@@ -212,7 +282,7 @@ Item {
         icon.name: "window-pin"
         display: PlasmaComponents3.AbstractButton.IconOnly
         checkable: true
-        checked: Boolean(plasmoid.configuration.keepOpen)
+        checked: Boolean(plasmoid.configuration.pin)
         onToggled: plasmoid.configuration.pin = checked
         visible: !Boolean(plasmoid.configuration.hideKeepOpen)
         z: 3
@@ -236,88 +306,5 @@ Item {
         PlasmaComponents3.ToolTip.visible: hovered
     }
 
-    // Helper Functions
-    // Returns the number of available chat models
-    function getModelsLength() {
-        return urlComboBox.model.length;
-    }
-
-    // Updates the chat model list and current selection
-    // Handles both predefined and custom chat models
-    function renderChatModel() {
-        // Create model list from enabled predefined models
-        const chatModel = models.filter(model => !model.prop.startsWith("showCustom_") && plasmoid.configuration[model.prop]).map(model => model.text)
-        // Add custom sites to the model list
-        .concat((plasmoid.configuration.customSites || "").split(',').filter(site => site?.includes('|')).map(site => site.split('|')[0])).concat([i18n("Custom URL...")]);
-
-        // Update ComboBox model and select current item
-        urlComboBox.model = chatModel;
-
-        const currentUrl = plasmoid.configuration.url;
-        const currentModel = models.find(model => !model.prop.startsWith("showCustom_") && model.url === currentUrl);
-
-        if (currentModel) {
-            const index = chatModel.indexOf(currentModel.text);
-            urlComboBox.currentIndex = index;
-            urlComboBox.editable = false;
-        } else {
-            const customSite = (plasmoid.configuration.customSites || "").split(',').find(site => site?.includes('|') && site.split('|')[1] === currentUrl);
-
-            if (customSite) {
-                const siteName = customSite.split('|')[0];
-                const index = chatModel.indexOf(siteName);
-                urlComboBox.currentIndex = index;
-                urlComboBox.editable = false;
-            } else {
-                urlComboBox.currentIndex = chatModel.length - 1;
-                urlComboBox.customUrlText = currentUrl;
-                urlComboBox.editText = currentUrl;
-                urlComboBox.editable = true;
-            }
-        }
-    }
-
-    // Handles model selection from ComboBox
-    // Updates current URL and navigates to selected chat
-    function handleModelSelection() {
-        if (urlComboBox.currentIndex === urlComboBox.count - 1) {
-            // Custom URL handling
-            let url = urlComboBox.editText;
-            if (url) {
-                plasmoid.configuration.url = url.match(/^https?:\/\//) ? url : "https://" + url;
-                goBackToHomePage();
-            }
-            return;
-        }
-
-        const selectedText = urlComboBox.currentText;
-        if (!selectedText)
-            return;
-
-        const selectedModel = models.find(model => !model.prop.startsWith("showCustom_") && model.text === selectedText);
-        if (selectedModel) {
-            plasmoid.configuration.url = selectedModel.url;
-            goBackToHomePage();
-            return;
-        }
-
-        const customSite = (plasmoid.configuration.customSites || "").split(',').find(site => site?.split('|')[0] === selectedText);
-        if (customSite) {
-            plasmoid.configuration.url = customSite.split('|')[1];
-            goBackToHomePage();
-        }
-    }
-
-    // Reactive snapshot of all model visibility states.
-    readonly property var modelVisibilityState: {
-        const snapshot = [plasmoid.configuration.customSites];
-        if (models) {
-            for (let i = 0; i < models.length; i++) {
-                snapshot.push(plasmoid.configuration[models[i].prop]);
-            }
-        }
-        return snapshot;
-    }
-    onModelVisibilityStateChanged: renderChatModel()
     } // close RowLayout
 } // close Item

--- a/contents/ui/Header.qml
+++ b/contents/ui/Header.qml
@@ -2,13 +2,29 @@ import QtCore
 import QtQuick
 import QtQuick.Dialogs
 import QtQuick.Layouts
-import org.kde.plasma.components 3.0 as PlasmaComponents3
+import org.kde.plasma.components as PlasmaComponents3
 import org.kde.kirigami as Kirigami
 import org.kde.plasma.plasmoid
 import QtWebEngine
 
-RowLayout {
+Item {
     Layout.fillWidth: true
+    implicitHeight: headerRow.implicitHeight
+
+    // Header gradient background
+    Rectangle {
+        anchors.fill: parent
+        visible: plasmoid.configuration.headerGradient
+        gradient: Gradient {
+            GradientStop { position: 0.0; color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.15) }
+            GradientStop { position: 1.0; color: "transparent" }
+        }
+        radius: Kirigami.Units.smallSpacing
+    }
+
+    RowLayout {
+        id: headerRow
+        anchors.fill: parent
 
     // Signals for communication with parent components
     signal goBackToHomePage
@@ -302,9 +318,6 @@ RowLayout {
     }
 
     // Reactive snapshot of all model visibility states.
-    // QML automatically re-evaluates this binding whenever any accessed
-    // configuration property changes, so adding a new service to `models`
-    // requires no additional signal handler here.
     readonly property var modelVisibilityState: {
         const snapshot = [plasmoid.configuration.customSites];
         if (models) {
@@ -315,4 +328,5 @@ RowLayout {
         return snapshot;
     }
     onModelVisibilityStateChanged: renderChatModel()
-}
+    } // close RowLayout
+} // close Item

--- a/contents/ui/Header.qml
+++ b/contents/ui/Header.qml
@@ -282,8 +282,8 @@ Item {
         icon.name: "window-pin"
         display: PlasmaComponents3.AbstractButton.IconOnly
         checkable: true
-        checked: Boolean(plasmoid.configuration.pin)
-        onToggled: plasmoid.configuration.pin = checked
+        checked: Boolean(plasmoid.configuration.keepOpen)
+        onToggled: plasmoid.configuration.keepOpen = checked
         visible: !Boolean(plasmoid.configuration.hideKeepOpen)
         z: 3
         PlasmaComponents3.ToolTip.text: checked ? i18n("Widget will stay open when clicking outside") : i18n("Widget will close when clicking outside")

--- a/contents/ui/Header.qml
+++ b/contents/ui/Header.qml
@@ -19,6 +19,7 @@ Item {
     signal navigateForwardRequested
     signal printPageRequested
     signal toggleSearchRequested
+    signal injectTransparencyRequested
 
     // Properties for managing component state
     property var closeWebViewCallback: undefined
@@ -264,6 +265,19 @@ Item {
         id: folderDialog
         currentFolder: plasmoid.configuration.downloadPath || StandardPaths.writableLocation(StandardPaths.DownloadLocation)
         onAccepted: plasmoid.configuration.downloadPath = selectedFolder
+    }
+
+    // Toggle blur button
+    PlasmaComponents3.Button {
+        icon.name: plasmoid.configuration.enableBlur ? "blur" : "edit-opacity"
+        display: PlasmaComponents3.AbstractButton.IconOnly
+        checkable: true
+        checked: plasmoid.configuration.enableBlur
+        onToggled: injectTransparencyRequested()
+        z: 3
+        PlasmaComponents3.ToolTip.text: checked ? i18n("Blur enabled — click to disable") : i18n("Blur disabled — click to enable")
+        PlasmaComponents3.ToolTip.delay: Kirigami.Units.toolTipDelay
+        PlasmaComponents3.ToolTip.visible: hovered
     }
 
     // Search button - Toggles the find bar

--- a/contents/ui/Header.qml
+++ b/contents/ui/Header.qml
@@ -1,10 +1,10 @@
+import QtCore
 import QtQuick
 import QtQuick.Dialogs
 import QtQuick.Layouts
 import org.kde.plasma.components 3.0 as PlasmaComponents3
 import org.kde.kirigami as Kirigami
 import org.kde.plasma.plasmoid
-import Qt.labs.platform 1.1
 import QtWebEngine
 
 RowLayout {

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -288,32 +288,45 @@ Item {
                         return m ? { r: m[1], g: m[2], b: m[3] } : null;
                     }
 
-                    // Check if element is chat content (input, output, messages) — never apply transparency
+                    // Check if element is or contains chat content — never apply transparency
                     function isChatContent(el) {
                         var tag = el.tagName.toLowerCase();
-                        // Interactive input elements
-                        if (['input', 'textarea', 'select', 'button', 'fieldset', 'form', 'p', 'pre', 'code', 'li', 'ol', 'ul', 'blockquote', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'a', 'strong', 'em', 'table'].indexOf(tag) >= 0) return true;
+                        // Text content tags
+                        if (['p', 'pre', 'code', 'li', 'ol', 'ul', 'blockquote', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'strong', 'em', 'table'].indexOf(tag) >= 0) return true;
+                        // Interactive elements
+                        if (['input', 'textarea', 'select', 'button', 'fieldset', 'form'].indexOf(tag) >= 0) return true;
                         if (el.isContentEditable || el.getAttribute('contenteditable') === 'true') return true;
                         var role = el.getAttribute('role') || '';
                         if (['textbox', 'searchbox', 'combobox', 'listbox', 'dialog', 'form', 'article', 'log', 'status'].indexOf(role) >= 0) return true;
                         var cls = (el.className && typeof el.className === 'string') ? el.className.toLowerCase() : '';
-                        // Input areas
-                        if (cls.match(/input|textarea|chat-input|prompt|editor|compose|message-input|ql-editor|ql-container|rich-textarea|text-input|send-button|input-area/)) return true;
-                        // Chat output / messages
+                        if (cls.match(/input|textarea|chat-input|prompt|editor|compose|message-input|ql-editor|ql-container|rich-textarea|text-input|send-button|input-area|tiptap|prosemirror/)) return true;
                         if (cls.match(/message|response|answer|reply|conversation|chat-turn|turn-|assistant|user-|bot-|markdown|prose|result|output/)) return true;
-                        // Data attributes commonly used for chat
-                        if (el.getAttribute('data-message-id') || el.getAttribute('data-testid')?.match(/message|conversation|turn/)) return true;
-                        // Contains text content directly (likely a message)
-                        if (el.querySelectorAll('textarea, input, [contenteditable=true], [role=textbox], .ql-editor').length > 0) return true;
+                        var testid = el.getAttribute('data-testid') || '';
+                        if (testid.match(/message|conversation|turn|chat-input|file-upload/)) return true;
+                        if (el.getAttribute('data-message-id')) return true;
                         return false;
+                    }
+
+                    // Check if element contains any chat content children
+                    function containsChatContent(el) {
+                        if (isChatContent(el)) return true;
+                        var found = el.querySelector(
+                            'textarea, input, [contenteditable=true], [role=textbox], ' +
+                            'fieldset, form, .ql-editor, .tiptap, .ProseMirror, ' +
+                            '[data-testid*=chat-input], [data-testid*=message], ' +
+                            '[class*=message], [class*=conversation], [class*=chat-turn], ' +
+                            '[class*=input-area], [class*=prompt], [class*=prose], ' +
+                            'p[data-placeholder], p[data-path-to-node]'
+                        );
+                        return found !== null;
                     }
 
                     function classifyElement(el) {
                         var rect = el.getBoundingClientRect();
                         if (rect.width < 10 || rect.height < 10) return 'skip';
 
-                        // Never touch interactive/input areas
-                        if (isChatContent(el)) return 'skip';
+                        // Never touch chat content or containers holding chat content
+                        if (isChatContent(el) || containsChatContent(el)) return 'skip';
 
                         var style = getComputedStyle(el);
                         var tag = el.tagName.toLowerCase();
@@ -337,7 +350,7 @@ Item {
                             return 'chrome';
                         }
 
-                        // Large background containers (wrappers, layouts, main content bg)
+                        // Large background containers — only if they don't hold chat
                         if (rect.width > viewW * 0.5 && rect.height > viewH * 0.3) {
                             return 'background';
                         }
@@ -350,9 +363,6 @@ Item {
                     allEls.forEach(function(el) {
                         var sel = makeSelector(el);
                         if (!sel || processed.has(sel)) return;
-
-                        // Skip interactive areas and their ancestors
-                        if (isChatContent(el)) return;
 
                         var color = parseBgColor(el);
                         if (!color) return;

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -175,10 +175,6 @@ Item {
     // Re-inject CSS when settings change live
     Connections {
         target: plasmoid.configuration
-        function onBackgroundTransparencyChanged() {
-            if (webview.url.toString() && plasmoid.configuration.enableBlur)
-                webview.runJavaScript("if(window._chatai_applyBlur){window._chatai_alpha=" + plasmoid.configuration.backgroundTransparency + ";window._chatai_applyBlur();}");
-        }
         function onEnableBlurChanged() { if (webview.url.toString()) webview.injectTransparencyCSS(); }
         function onFocusModeChanged() { if (webview.url.toString()) webview.injectFocusMode(); }
     }
@@ -285,12 +281,11 @@ Item {
                 );
                 return;
             }
-            var alpha = plasmoid.configuration.backgroundTransparency;
             webview.runJavaScript(
                 "(function() { try {" +
-                "  window._chatai_alpha = " + alpha + ";" +
                 "  window._chatai_applyBlur = function() {" +
-                "    var a = window._chatai_alpha;" +
+                "    var a = 0.5;" +
+                "    var b = 8;" +
                 "    document.documentElement.style.setProperty('background-color', 'transparent', 'important');" +
                 "    document.body.style.setProperty('background-color', 'transparent', 'important');" +
                 "    document.body.querySelectorAll('body > *, body > * > *').forEach(function(el) {" +
@@ -301,8 +296,8 @@ Item {
                 "      var m = bg.match(/rgba?\\((\\d+),\\s*(\\d+),\\s*(\\d+)/);" +
                 "      if (!m) return;" +
                 "      el.style.setProperty('background-color', 'rgba(' + m[1] + ',' + m[2] + ',' + m[3] + ',' + a + ')', 'important');" +
-                "      el.style.setProperty('backdrop-filter', 'blur(8px)', 'important');" +
-                "      el.style.setProperty('-webkit-backdrop-filter', 'blur(8px)', 'important');" +
+                "      el.style.setProperty('backdrop-filter', 'blur(' + b + 'px)', 'important');" +
+                "      el.style.setProperty('-webkit-backdrop-filter', 'blur(' + b + 'px)', 'important');" +
                 "    });" +
                 "  };" +
                 "  window._chatai_applyBlur();" +

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -2,7 +2,6 @@ import QtCore
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
-import QtQuick.Effects
 import QtQuick.Layouts
 import QtWebEngine
 import org.kde.plasma.components as PlasmaComponents3
@@ -682,7 +681,7 @@ Item {
         }
     }
 
-    Item {
+    Rectangle {
         id: statusBubble
 
         property int padding: 8
@@ -694,22 +693,9 @@ Item {
         width: statusText.paintedWidth + padding * 2
         height: statusText.paintedHeight + padding
         z: 5
-
-        Rectangle {
-            id: statusBg
-            anchors.fill: parent
-            color: Kirigami.Theme.backgroundColor
-            opacity: plasmoid.configuration.enableBlurEffects ? plasmoid.configuration.overlayOpacity : 0.9
-            radius: Kirigami.Units.smallSpacing
-        }
-
-        MultiEffect {
-            source: statusBg
-            anchors.fill: statusBg
-            blurEnabled: plasmoid.configuration.enableBlurEffects
-            blur: 1.0
-            blurMax: 32
-        }
+        color: Kirigami.Theme.backgroundColor
+        opacity: plasmoid.configuration.overlayOpacity
+        radius: Kirigami.Units.smallSpacing
 
         Text {
             id: statusText

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -19,7 +19,12 @@ Item {
         return StandardPaths.writableLocation(StandardPaths.DownloadLocation);
     }
 
+    function toggleBlur() {
+        plasmoid.configuration.enableBlur = !plasmoid.configuration.enableBlur;
+    }
+
     function goBackToHomePage() {
+        plasmoid.configuration.lastVisitedUrl = "";
         webview.url = plasmoid.configuration.url;
     }
 
@@ -132,7 +137,6 @@ Item {
         id: webNotification
         componentName: "chatai_plasmoid"
         eventId: "notification"
-        defaultAction: i18n("Open")
         title: i18n("ChatAI")
         iconName: "dialog-information"
     }
@@ -171,8 +175,11 @@ Item {
     // Re-inject CSS when settings change live
     Connections {
         target: plasmoid.configuration
-        function onEnableTransparencyChanged() { if (webview.url.toString()) webview.injectTransparencyCSS(); }
-        function onBackgroundTransparencyChanged() { if (webview.url.toString()) webview.injectTransparencyCSS(); }
+        function onBackgroundTransparencyChanged() {
+            if (webview.url.toString() && plasmoid.configuration.enableBlur)
+                webview.runJavaScript("if(window._chatai_applyBlur){window._chatai_alpha=" + plasmoid.configuration.backgroundTransparency + ";window._chatai_applyBlur();}");
+        }
+        function onEnableBlurChanged() { if (webview.url.toString()) webview.injectTransparencyCSS(); }
         function onFocusModeChanged() { if (webview.url.toString()) webview.injectFocusMode(); }
     }
 
@@ -246,149 +253,69 @@ Item {
     WebEngineView {
         id: webview
 
-        // Transparent WebEngine background when transparency is enabled
-        backgroundColor: plasmoid.configuration.enableTransparency ? "transparent" : Kirigami.Theme.backgroundColor
+        property bool _forceOpaque: false
+        backgroundColor: (!plasmoid.configuration.enableBlur || _forceOpaque) ? Kirigami.Theme.backgroundColor : "transparent"
 
-        // Smart transparency: analyzes DOM structure and applies layered
-        // transparency + backdrop-blur based on element role
+        // Brief opacity flip to force WebEngine compositing reset
+        Timer {
+            id: bgFlipTimer
+            interval: 50
+            onTriggered: webview._forceOpaque = false
+        }
+        function kickTransparency() {
+            _forceOpaque = true;
+            bgFlipTimer.start();
+        }
+
+        // Background-only transparency: inline styles on html/body and
+        // top-level wrapper elements, leaving all content areas intact
         function injectTransparencyCSS() {
-            if (!plasmoid.configuration.enableTransparency) {
-                webview.runJavaScript("
-                    var el = document.getElementById('_chatai_transparency');
-                    if (el) el.remove();
-                ");
+            if (!plasmoid.configuration.enableBlur) {
+                webview.runJavaScript(
+                    "(function() { try {" +
+                    "  if (window._chatai_resizeHandler) { window.removeEventListener('resize', window._chatai_resizeHandler); window._chatai_resizeHandler = null; }" +
+                    "  document.documentElement.style.removeProperty('background-color');" +
+                    "  document.body.style.removeProperty('background-color');" +
+                    "  document.body.querySelectorAll('body > *, body > * > *').forEach(function(el) {" +
+                    "    el.style.removeProperty('background-color');" +
+                    "    el.style.removeProperty('backdrop-filter');" +
+                    "    el.style.removeProperty('-webkit-backdrop-filter');" +
+                    "  });" +
+                    "} catch(e) {} })();"
+                );
                 return;
             }
-
             var alpha = plasmoid.configuration.backgroundTransparency;
-            webview.runJavaScript("
-                (function() {
-                    var styleId = '_chatai_transparency';
-                    var existing = document.getElementById(styleId);
-                    if (existing) existing.remove();
-
-                    var alpha = " + alpha + ";
-                    var viewW = window.innerWidth;
-                    var viewH = window.innerHeight;
-                    var css = 'html, body { background-color: transparent !important; }\\n';
-                    var processed = new Set();
-
-                    function makeSelector(el) {
-                        if (el.id) return '#' + CSS.escape(el.id);
-                        if (el.tagName === 'HTML' || el.tagName === 'BODY') return el.tagName.toLowerCase();
-                        var cls = el.className && typeof el.className === 'string' ? el.className.trim().split(/\\s+/)[0] : '';
-                        if (cls) return el.tagName.toLowerCase() + '.' + CSS.escape(cls);
-                        return null;
-                    }
-
-                    function parseBgColor(el) {
-                        var bg = getComputedStyle(el).backgroundColor;
-                        if (!bg || bg === 'rgba(0, 0, 0, 0)' || bg === 'transparent') return null;
-                        var m = bg.match(/rgba?\\((\\d+),\\s*(\\d+),\\s*(\\d+)/);
-                        return m ? { r: m[1], g: m[2], b: m[3] } : null;
-                    }
-
-                    // Check if element is or contains chat content — never apply transparency
-                    function isChatContent(el) {
-                        var tag = el.tagName.toLowerCase();
-                        // Text content tags
-                        if (['p', 'pre', 'code', 'li', 'ol', 'ul', 'blockquote', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'strong', 'em', 'table'].indexOf(tag) >= 0) return true;
-                        // Interactive elements
-                        if (['input', 'textarea', 'select', 'button', 'fieldset', 'form'].indexOf(tag) >= 0) return true;
-                        if (el.isContentEditable || el.getAttribute('contenteditable') === 'true') return true;
-                        var role = el.getAttribute('role') || '';
-                        if (['textbox', 'searchbox', 'combobox', 'listbox', 'dialog', 'form', 'article', 'log', 'status'].indexOf(role) >= 0) return true;
-                        var cls = (el.className && typeof el.className === 'string') ? el.className.toLowerCase() : '';
-                        if (cls.match(/input|textarea|chat-input|prompt|editor|compose|message-input|ql-editor|ql-container|rich-textarea|text-input|send-button|input-area|tiptap|prosemirror/)) return true;
-                        if (cls.match(/message|response|answer|reply|conversation|chat-turn|turn-|assistant|user-|bot-|markdown|prose|result|output/)) return true;
-                        var testid = el.getAttribute('data-testid') || '';
-                        if (testid.match(/message|conversation|turn|chat-input|file-upload/)) return true;
-                        if (el.getAttribute('data-message-id')) return true;
-                        return false;
-                    }
-
-                    // Check if element contains any chat content children
-                    function containsChatContent(el) {
-                        if (isChatContent(el)) return true;
-                        var found = el.querySelector(
-                            'textarea, input, [contenteditable=true], [role=textbox], ' +
-                            'fieldset, form, .ql-editor, .tiptap, .ProseMirror, ' +
-                            '[data-testid*=chat-input], [data-testid*=message], ' +
-                            '[class*=message], [class*=conversation], [class*=chat-turn], ' +
-                            '[class*=input-area], [class*=prompt], [class*=prose], ' +
-                            'p[data-placeholder], p[data-path-to-node]'
-                        );
-                        return found !== null;
-                    }
-
-                    function classifyElement(el) {
-                        var rect = el.getBoundingClientRect();
-                        if (rect.width < 10 || rect.height < 10) return 'skip';
-
-                        // Never touch chat content or containers holding chat content
-                        if (isChatContent(el) || containsChatContent(el)) return 'skip';
-
-                        var style = getComputedStyle(el);
-                        var tag = el.tagName.toLowerCase();
-                        var role = el.getAttribute('role') || '';
-                        var cls = (el.className && typeof el.className === 'string') ? el.className.toLowerCase() : '';
-
-                        // Sidebars & navigation: high blur, very transparent
-                        if (tag === 'nav' || tag === 'aside' || role === 'navigation' || role === 'complementary' ||
-                            cls.match(/sidebar|sidenav|drawer|panel/)) {
-                            return 'chrome';
-                        }
-
-                        // Headers/toolbars: medium blur
-                        if (tag === 'header' || role === 'banner' || cls.match(/header|toolbar|topbar|appbar/)) {
-                            if (rect.height < 120) return 'chrome';
-                        }
-
-                        // Fixed/sticky narrow panels
-                        if ((style.position === 'fixed' || style.position === 'sticky') &&
-                            rect.width < viewW * 0.35 && rect.height > viewH * 0.3) {
-                            return 'chrome';
-                        }
-
-                        // Large background containers — only if they don't hold chat
-                        if (rect.width > viewW * 0.5 && rect.height > viewH * 0.3) {
-                            return 'background';
-                        }
-
-                        return 'skip';
-                    }
-
-                    // Walk all elements with backgrounds
-                    var allEls = document.querySelectorAll('*');
-                    allEls.forEach(function(el) {
-                        var sel = makeSelector(el);
-                        if (!sel || processed.has(sel)) return;
-
-                        var color = parseBgColor(el);
-                        if (!color) return;
-
-                        var type = classifyElement(el);
-                        if (type === 'skip') return;
-
-                        processed.add(sel);
-
-                        if (type === 'chrome') {
-                            // Sidebars/headers: very transparent + strong blur
-                            css += sel + ' { background-color: rgba(' + color.r + ',' + color.g + ',' + color.b + ',' + (alpha * 0.3).toFixed(3) + ') !important; ';
-                            css += 'backdrop-filter: blur(8px) !important; -webkit-backdrop-filter: blur(8px) !important; }\\n';
-                        } else if (type === 'background') {
-                            // Main content area: subtle transparency
-                            css += sel + ' { background-color: rgba(' + color.r + ',' + color.g + ',' + color.b + ',' + alpha.toFixed(3) + ') !important; ';
-                            css += 'backdrop-filter: blur(2px) !important; -webkit-backdrop-filter: blur(2px) !important; }\\n';
-                        }
-                    });
-
-                    var style = document.createElement('style');
-                    style.id = styleId;
-                    style.textContent = css;
-                    document.head.appendChild(style);
-                })();
-            ");
+            webview.runJavaScript(
+                "(function() { try {" +
+                "  window._chatai_alpha = " + alpha + ";" +
+                "  window._chatai_applyBlur = function() {" +
+                "    var a = window._chatai_alpha;" +
+                "    document.documentElement.style.setProperty('background-color', 'transparent', 'important');" +
+                "    document.body.style.setProperty('background-color', 'transparent', 'important');" +
+                "    document.body.querySelectorAll('body > *, body > * > *').forEach(function(el) {" +
+                "      var r = el.getBoundingClientRect();" +
+                "      if (r.width < window.innerWidth * 0.3) return;" +
+                "      var bg = getComputedStyle(el).backgroundColor;" +
+                "      if (!bg || bg === 'rgba(0, 0, 0, 0)' || bg === 'transparent') return;" +
+                "      var m = bg.match(/rgba?\\((\\d+),\\s*(\\d+),\\s*(\\d+)/);" +
+                "      if (!m) return;" +
+                "      el.style.setProperty('background-color', 'rgba(' + m[1] + ',' + m[2] + ',' + m[3] + ',' + a + ')', 'important');" +
+                "      el.style.setProperty('backdrop-filter', 'blur(8px)', 'important');" +
+                "      el.style.setProperty('-webkit-backdrop-filter', 'blur(8px)', 'important');" +
+                "    });" +
+                "  };" +
+                "  window._chatai_applyBlur();" +
+                "  if (!window._chatai_resizeHandler) {" +
+                "    var timer = null;" +
+                "    window._chatai_resizeHandler = function() {" +
+                "      clearTimeout(timer);" +
+                "      timer = setTimeout(window._chatai_applyBlur, 300);" +
+                "    };" +
+                "    window.addEventListener('resize', window._chatai_resizeHandler);" +
+                "  }" +
+                "} catch(e) {} })();"
+            );
         }
 
         property var downloadCache: ({})
@@ -501,8 +428,15 @@ Item {
         }
 
         anchors.fill: parent
-        url: plasmoid.configuration.url
+        url: plasmoid.configuration.lastVisitedUrl || plasmoid.configuration.url
         profile: webProfile
+
+        // Save current URL so it persists across WebView unload/reload
+        onUrlChanged: {
+            var u = url.toString();
+            if (u && u !== "about:blank" && u !== plasmoid.configuration.lastVisitedUrl)
+                plasmoid.configuration.lastVisitedUrl = u;
+        }
         onLinkHovered: hoveredUrl => {
             if (hoveredUrl == "") {
                 hideStatusText.start();
@@ -710,6 +644,7 @@ Item {
 
             if (!webview.loading) {
                 checkAndUpdateFavicon();
+                webview.kickTransparency();
                 injectTransparencyCSS();
                 injectFocusMode();
             }

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -246,13 +246,6 @@ Item {
     WebEngineView {
         id: webview
 
-        // Opacity follows load progress: 0% → 0.3, 100% → 1.0
-        opacity: loading ? 0.3 + (loadProgress / 100) * 0.7 : 1.0
-        Behavior on opacity {
-            enabled: plasmoid.configuration.enableAnimations
-            NumberAnimation { duration: 150; easing.type: Easing.OutQuad }
-        }
-
         // Transparent WebEngine background when transparency is enabled
         backgroundColor: plasmoid.configuration.enableTransparency ? "transparent" : Kirigami.Theme.backgroundColor
 
@@ -535,57 +528,6 @@ Item {
 
             request.grant();
         }
-        // CSS backdrop blur follows load progress — blurs background only, text stays sharp
-        function updateBlurForProgress(progress) {
-            var blurPx = Math.round(12 * (1 - progress / 100));
-            var overlayAlpha = (1 - progress / 100) * 0.3; // 0.3 at 0% → 0 at 100%
-            var subtle = plasmoid.configuration.enableTransparency ? 0.5 : 0;
-
-            webview.runJavaScript("
-                (function() {
-                    var s = document.getElementById('_chatai_blur');
-                    if (!s) {
-                        s = document.createElement('style');
-                        s.id = '_chatai_blur';
-                        document.head.appendChild(s);
-                    }
-
-                    var blur = " + blurPx + ";
-                    var alpha = " + overlayAlpha.toFixed(3) + ";
-                    var subtle = " + subtle + ";
-
-                    if (blur <= 0 && subtle <= 0) {
-                        s.textContent = '#_chatai_blur_overlay { display: none; }';
-                        return;
-                    }
-
-                    var finalBlur = blur > 0 ? blur : subtle;
-                    var finalAlpha = blur > 0 ? alpha : 0;
-
-                    s.textContent = `
-                        #_chatai_blur_overlay {
-                            position: fixed;
-                            inset: 0;
-                            z-index: 99999;
-                            pointer-events: none;
-                            backdrop-filter: blur(${finalBlur}px);
-                            -webkit-backdrop-filter: blur(${finalBlur}px);
-                            background: rgba(0,0,0,${finalAlpha});
-                            transition: backdrop-filter 0.15s ease-out, background 0.15s ease-out,
-                                        -webkit-backdrop-filter 0.15s ease-out;
-                        }
-                    `;
-
-                    // Create overlay element if needed
-                    if (!document.getElementById('_chatai_blur_overlay')) {
-                        var div = document.createElement('div');
-                        div.id = '_chatai_blur_overlay';
-                        document.documentElement.appendChild(div);
-                    }
-                })();
-            ");
-        }
-
         // Focus mode: hide sidebars, headers, and non-essential UI per service
         function injectFocusMode() {
             if (!plasmoid.configuration.focusMode) {
@@ -726,18 +668,10 @@ Item {
             ");
         }
 
-        onLoadProgressChanged: {
-            if (loading)
-                updateBlurForProgress(loadProgress);
-        }
-
         onLoadingChanged: {
             injectBrowserSpoof();
 
-            if (loading) {
-                updateBlurForProgress(0);
-            } else {
-                updateBlurForProgress(100);
+            if (!webview.loading) {
                 checkAndUpdateFavicon();
                 injectTransparencyCSS();
                 injectFocusMode();
@@ -971,15 +905,6 @@ Item {
         }
     }
 
-    // Loading spinner (content blur is handled via CSS injection)
-    PlasmaComponents3.BusyIndicator {
-        anchors.centerIn: parent
-        z: 3
-        running: webview.loading
-        visible: running
-        implicitWidth: Kirigami.Units.gridUnit * 3
-        implicitHeight: implicitWidth
-    }
 
     MouseArea {
         id: mouseArea

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -3,14 +3,11 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
 import QtQuick.Layouts
-import QtQuick.LocalStorage 2.0
 import QtWebEngine
-import Qt.labs.platform 1.1
 import org.kde.plasma.components as PlasmaComponents3
 import org.kde.plasma.core as PlasmaCore
-import org.kde.plasma.extras as PlasmaExtras
 import org.kde.plasma.plasmoid
-import org.kde.notification 1.0
+import org.kde.notification
 import org.kde.kirigami as Kirigami
 
 Item {
@@ -126,59 +123,57 @@ Item {
         onActivated: findBarVisible = true
     }
 
-    PlasmaExtras.Menu {
+    PlasmaComponents3.Menu {
         id: linkContextMenu
 
         property string link
 
-        visualParent: webview
-
-        PlasmaExtras.MenuItem {
+        PlasmaComponents3.MenuItem {
             text: i18n("Back")
-            icon: "go-previous"
+            icon.name: "go-previous"
             enabled: webview.canGoBack
-            onClicked: webview.goBack()
+            onTriggered: webview.goBack()
         }
 
-        PlasmaExtras.MenuItem {
+        PlasmaComponents3.MenuItem {
             text: i18n("Forward")
-            icon: "go-next"
+            icon.name: "go-next"
             enabled: webview.canGoForward
-            onClicked: webview.goForward()
+            onTriggered: webview.goForward()
         }
 
-        PlasmaExtras.MenuItem {
+        PlasmaComponents3.MenuItem {
             text: i18n("Reload")
-            icon: "view-refresh"
-            onClicked: reloadPage()
+            icon.name: "view-refresh"
+            onTriggered: reloadPage()
         }
 
-        PlasmaExtras.MenuItem {
+        PlasmaComponents3.MenuItem {
             text: i18n("Save as PDF")
-            icon: "document-save-as"
+            icon.name: "document-save-as"
             visible: !linkContextMenu.link
-            onClicked: printPage()
+            onTriggered: printPage()
         }
 
-        PlasmaExtras.MenuItem {
+        PlasmaComponents3.MenuItem {
             text: i18n("Save as MHTML")
-            icon: "document-save"
+            icon.name: "document-save"
             visible: !linkContextMenu.link
-            onClicked: saveMHTML()
+            onTriggered: saveMHTML()
         }
 
-        PlasmaExtras.MenuItem {
+        PlasmaComponents3.MenuItem {
             text: i18n("Open Link in Browser")
-            icon: "internet-web-browser"
+            icon.name: "internet-web-browser"
             visible: linkContextMenu.link !== ""
-            onClicked: Qt.openUrlExternally(linkContextMenu.link)
+            onTriggered: Qt.openUrlExternally(linkContextMenu.link)
         }
 
-        PlasmaExtras.MenuItem {
+        PlasmaComponents3.MenuItem {
             text: i18n("Copy Link Address")
-            icon: "edit-copy"
+            icon.name: "edit-copy"
             visible: linkContextMenu.link !== ""
-            onClicked: webview.triggerWebAction(WebEngineView.CopyLinkToClipboard)
+            onTriggered: webview.triggerWebAction(WebEngineView.CopyLinkToClipboard)
         }
     }
 
@@ -322,7 +317,7 @@ Item {
             linkContextMenu.link = hasLink ? request.linkUrl.toString() : "";
 
             // Always show our custom menu when it's not a special element
-            linkContextMenu.open(request.position.x, request.position.y);
+            linkContextMenu.popup(request.position.x, request.position.y);
             request.accepted = true;
         }
 
@@ -422,15 +417,6 @@ Item {
                 ");
             }
         }
-        onFeaturePermissionRequested: function (securityOrigin, feature) {
-            if (feature === WebEngineView.MediaAudioCapture)
-                grantFeaturePermission(securityOrigin, feature, plasmoid.configuration.microphoneEnabled);
-            else if (feature === WebEngineView.MediaVideoCapture)
-                grantFeaturePermission(securityOrigin, feature, plasmoid.configuration.webcamEnabled);
-            else if (feature === WebEngineView.DesktopAudioVideoCapture)
-                grantFeaturePermission(securityOrigin, feature, plasmoid.configuration.screenShareEnabled);
-        }
-
         onPrintRequested: function () {
             webview.triggerWebAction(WebEngineView.Print);
         }

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -186,12 +186,6 @@ Item {
     WebEngineView {
         id: webview
 
-        opacity: loading ? 0.6 : 1.0
-        Behavior on opacity {
-            enabled: plasmoid.configuration.enableAnimations
-            NumberAnimation { duration: 300; easing.type: Easing.InOutQuad }
-        }
-
         // Transparent WebEngine background when transparency is enabled
         backgroundColor: plasmoid.configuration.enableTransparency ? "transparent" : Kirigami.Theme.backgroundColor
 
@@ -419,7 +413,36 @@ Item {
 
             request.grant();
         }
+        // Inject CSS blur: max on load start, eases to subtle on load end
+        function injectLoadingBlur(loading) {
+            if (loading) {
+                webview.runJavaScript("
+                    (function() {
+                        var s = document.getElementById('_chatai_blur');
+                        if (!s) {
+                            s = document.createElement('style');
+                            s.id = '_chatai_blur';
+                            document.head.appendChild(s);
+                        }
+                        s.textContent = 'html { filter: blur(8px) saturate(0.5); transition: filter 0.3s ease-out; }';
+                    })();
+                ");
+            } else {
+                var subtle = plasmoid.configuration.enableTransparency ? "blur(0.5px)" : "none";
+                webview.runJavaScript("
+                    (function() {
+                        var s = document.getElementById('_chatai_blur');
+                        if (s) {
+                            s.textContent = 'html { filter: " + subtle + "; transition: filter 0.8s ease-in-out; }';
+                        }
+                    })();
+                ");
+            }
+        }
+
         onLoadingChanged: {
+            injectLoadingBlur(webview.loading);
+
             if (!webview.loading) {
                 checkAndUpdateFavicon();
                 injectTransparencyCSS();
@@ -653,27 +676,14 @@ Item {
         }
     }
 
-    // Loading overlay — fades in during load, fades out when done
-    Rectangle {
-        id: loadingOverlay
-        anchors.fill: parent
-        color: Kirigami.Theme.backgroundColor
-        opacity: webview.loading ? 0.4 : 0.0
-        visible: opacity > 0
+    // Loading spinner (content blur is handled via CSS injection)
+    PlasmaComponents3.BusyIndicator {
+        anchors.centerIn: parent
         z: 3
-
-        Behavior on opacity {
-            enabled: plasmoid.configuration.enableAnimations
-            NumberAnimation { duration: 400; easing.type: Easing.InOutQuad }
-        }
-
-        PlasmaComponents3.BusyIndicator {
-            anchors.centerIn: parent
-            running: webview.loading
-            visible: running
-            implicitWidth: Kirigami.Units.gridUnit * 3
-            implicitHeight: implicitWidth
-        }
+        running: webview.loading
+        visible: running
+        implicitWidth: Kirigami.Units.gridUnit * 3
+        implicitHeight: implicitWidth
     }
 
     MouseArea {

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -256,7 +256,8 @@ Item {
         // Transparent WebEngine background when transparency is enabled
         backgroundColor: plasmoid.configuration.enableTransparency ? "transparent" : Kirigami.Theme.backgroundColor
 
-        // Inject CSS to make the website background semi-transparent
+        // Smart transparency: analyzes DOM structure and applies layered
+        // transparency + backdrop-blur based on element role
         function injectTransparencyCSS() {
             if (!plasmoid.configuration.enableTransparency) {
                 webview.runJavaScript("
@@ -266,35 +267,89 @@ Item {
                 return;
             }
 
-            var opacity = plasmoid.configuration.backgroundTransparency;
+            var alpha = plasmoid.configuration.backgroundTransparency;
             webview.runJavaScript("
                 (function() {
                     var styleId = '_chatai_transparency';
                     var existing = document.getElementById(styleId);
                     if (existing) existing.remove();
 
-                    // Grab computed bg colors and make them semi-transparent
-                    var targets = document.querySelectorAll(
-                        'html, body, body > *:first-child, body > div:first-of-type, ' +
-                        'main, #__next, #root, #app, .app, ' +
-                        '[class*=\"layout\"], [class*=\"Layout\"], ' +
-                        '[class*=\"container\"], [class*=\"Container\"], ' +
-                        '[class*=\"wrapper\"], [class*=\"Wrapper\"]'
-                    );
-
+                    var alpha = " + alpha + ";
+                    var viewW = window.innerWidth;
+                    var viewH = window.innerHeight;
                     var css = 'html, body { background-color: transparent !important; }\\n';
+                    var processed = new Set();
 
-                    targets.forEach(function(el) {
+                    function makeSelector(el) {
+                        if (el.id) return '#' + CSS.escape(el.id);
+                        if (el.tagName === 'HTML' || el.tagName === 'BODY') return el.tagName.toLowerCase();
+                        var cls = el.className && typeof el.className === 'string' ? el.className.trim().split(/\\s+/)[0] : '';
+                        if (cls) return el.tagName.toLowerCase() + '.' + CSS.escape(cls);
+                        return null;
+                    }
+
+                    function parseBgColor(el) {
                         var bg = getComputedStyle(el).backgroundColor;
-                        if (bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent') {
-                            // Parse rgb/rgba and apply opacity
-                            var match = bg.match(/rgba?\\((\\d+),\\s*(\\d+),\\s*(\\d+)/);
-                            if (match) {
-                                var r = match[1], g = match[2], b = match[3];
-                                var selector = el.id ? '#' + el.id :
-                                    el.tagName.toLowerCase() + (el.className ? '.' + el.className.split(' ')[0] : '');
-                                css += selector + ' { background-color: rgba(' + r + ',' + g + ',' + b + ',' + " + opacity + " + ') !important; }\\n';
-                            }
+                        if (!bg || bg === 'rgba(0, 0, 0, 0)' || bg === 'transparent') return null;
+                        var m = bg.match(/rgba?\\((\\d+),\\s*(\\d+),\\s*(\\d+)/);
+                        return m ? { r: m[1], g: m[2], b: m[3] } : null;
+                    }
+
+                    function classifyElement(el) {
+                        var rect = el.getBoundingClientRect();
+                        if (rect.width < 10 || rect.height < 10) return 'skip';
+                        var style = getComputedStyle(el);
+                        var tag = el.tagName.toLowerCase();
+                        var role = el.getAttribute('role') || '';
+                        var cls = (el.className && typeof el.className === 'string') ? el.className.toLowerCase() : '';
+
+                        // Sidebars & navigation: high blur, very transparent
+                        if (tag === 'nav' || tag === 'aside' || role === 'navigation' || role === 'complementary' ||
+                            cls.match(/sidebar|sidenav|drawer|panel/)) {
+                            return 'chrome';
+                        }
+
+                        // Headers/toolbars: medium blur
+                        if (tag === 'header' || role === 'banner' || cls.match(/header|toolbar|topbar|appbar/)) {
+                            if (rect.height < 120) return 'chrome';
+                        }
+
+                        // Fixed/sticky narrow panels
+                        if ((style.position === 'fixed' || style.position === 'sticky') &&
+                            rect.width < viewW * 0.35 && rect.height > viewH * 0.3) {
+                            return 'chrome';
+                        }
+
+                        // Large background containers (wrappers, layouts, main content bg)
+                        if (rect.width > viewW * 0.5 && rect.height > viewH * 0.3) {
+                            return 'background';
+                        }
+
+                        return 'skip';
+                    }
+
+                    // Walk all elements with backgrounds
+                    var allEls = document.querySelectorAll('*');
+                    allEls.forEach(function(el) {
+                        var sel = makeSelector(el);
+                        if (!sel || processed.has(sel)) return;
+
+                        var color = parseBgColor(el);
+                        if (!color) return;
+
+                        var type = classifyElement(el);
+                        if (type === 'skip') return;
+
+                        processed.add(sel);
+
+                        if (type === 'chrome') {
+                            // Sidebars/headers: very transparent + strong blur
+                            css += sel + ' { background-color: rgba(' + color.r + ',' + color.g + ',' + color.b + ',' + (alpha * 0.3).toFixed(3) + ') !important; ';
+                            css += 'backdrop-filter: blur(8px) !important; -webkit-backdrop-filter: blur(8px) !important; }\\n';
+                        } else if (type === 'background') {
+                            // Main content area: subtle transparency
+                            css += sel + ' { background-color: rgba(' + color.r + ',' + color.g + ',' + color.b + ',' + alpha.toFixed(3) + ') !important; ';
+                            css += 'backdrop-filter: blur(2px) !important; -webkit-backdrop-filter: blur(2px) !important; }\\n';
                         }
                     });
 

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -245,6 +245,13 @@ Item {
     WebEngineView {
         id: webview
 
+        // Dim while loading — CSS blur handles the rest once document is ready
+        opacity: loading ? 0.3 : 1.0
+        Behavior on opacity {
+            enabled: plasmoid.configuration.enableAnimations
+            NumberAnimation { duration: loading ? 100 : 800; easing.type: Easing.InOutQuad }
+        }
+
         // Transparent WebEngine background when transparency is enabled
         backgroundColor: plasmoid.configuration.enableTransparency ? "transparent" : Kirigami.Theme.backgroundColor
 
@@ -472,38 +479,31 @@ Item {
 
             request.grant();
         }
-        // Inject CSS blur: max on load start, eases to subtle on load end
-        function injectLoadingBlur(loading) {
-            if (loading) {
-                webview.runJavaScript("
-                    (function() {
-                        var s = document.getElementById('_chatai_blur');
-                        if (!s) {
-                            s = document.createElement('style');
-                            s.id = '_chatai_blur';
-                            document.head.appendChild(s);
-                        }
-                        s.textContent = 'html { filter: blur(8px) saturate(0.5); transition: filter 0.3s ease-out; }';
-                    })();
-                ");
-            } else {
-                var subtle = plasmoid.configuration.enableTransparency ? "blur(0.5px)" : "none";
-                webview.runJavaScript("
-                    (function() {
-                        var s = document.getElementById('_chatai_blur');
-                        if (s) {
-                            s.textContent = 'html { filter: " + subtle + "; transition: filter 0.8s ease-in-out; }';
-                        }
-                    })();
-                ");
-            }
+        // CSS blur injection: heavy blur during load, smooth unblur when done
+        function injectUnblur() {
+            var subtle = plasmoid.configuration.enableTransparency ? "blur(0.5px)" : "none";
+            webview.runJavaScript("
+                (function() {
+                    var s = document.getElementById('_chatai_blur');
+                    if (!s) {
+                        s = document.createElement('style');
+                        s.id = '_chatai_blur';
+                        document.head.appendChild(s);
+                    }
+                    // Start blurred, then transition to clear
+                    s.textContent = 'html { filter: blur(12px) saturate(0.4) brightness(0.9); }';
+                    requestAnimationFrame(function() {
+                        s.textContent = 'html { filter: " + subtle + "; transition: filter 1.2s cubic-bezier(0.4, 0, 0.2, 1); }';
+                    });
+                })();
+            ");
         }
 
         onLoadingChanged: {
             injectBrowserSpoof();
-            injectLoadingBlur(webview.loading);
 
             if (!webview.loading) {
+                injectUnblur();
                 checkAndUpdateFavicon();
                 injectTransparencyCSS();
             }

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -2,6 +2,7 @@ import QtCore
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
+import QtQuick.Effects
 import QtQuick.Layouts
 import QtWebEngine
 import org.kde.plasma.components as PlasmaComponents3
@@ -178,6 +179,12 @@ Item {
 
     WebEngineView {
         id: webview
+
+        opacity: loading ? 0.6 : 1.0
+        Behavior on opacity {
+            enabled: plasmoid.configuration.enableAnimations
+            NumberAnimation { duration: 300; easing.type: Easing.InOutQuad }
+        }
 
         property var downloadCache: ({})
 
@@ -586,6 +593,29 @@ Item {
         }
     }
 
+    // Loading overlay — fades in during load, fades out when done
+    Rectangle {
+        id: loadingOverlay
+        anchors.fill: parent
+        color: Kirigami.Theme.backgroundColor
+        opacity: webview.loading ? 0.4 : 0.0
+        visible: opacity > 0
+        z: 3
+
+        Behavior on opacity {
+            enabled: plasmoid.configuration.enableAnimations
+            NumberAnimation { duration: 400; easing.type: Easing.InOutQuad }
+        }
+
+        PlasmaComponents3.BusyIndicator {
+            anchors.centerIn: parent
+            running: webview.loading
+            visible: running
+            implicitWidth: Kirigami.Units.gridUnit * 3
+            implicitHeight: implicitWidth
+        }
+    }
+
     MouseArea {
         id: mouseArea
 
@@ -599,22 +629,39 @@ Item {
         }
     }
 
-    Rectangle {
+    Item {
         id: statusBubble
 
         property int padding: 8
 
-        color: Kirigami.Theme.backgroundColor
         visible: false
         anchors.left: parent.left
         anchors.bottom: parent.bottom
-        width: statusText.paintedWidth + padding
+        anchors.margins: Kirigami.Units.smallSpacing
+        width: statusText.paintedWidth + padding * 2
         height: statusText.paintedHeight + padding
+        z: 5
+
+        Rectangle {
+            id: statusBg
+            anchors.fill: parent
+            color: Kirigami.Theme.backgroundColor
+            opacity: plasmoid.configuration.enableBlurEffects ? plasmoid.configuration.overlayOpacity : 0.9
+            radius: Kirigami.Units.smallSpacing
+        }
+
+        MultiEffect {
+            source: statusBg
+            anchors.fill: statusBg
+            blurEnabled: plasmoid.configuration.enableBlurEffects
+            blur: 1.0
+            blurMax: 32
+        }
 
         Text {
             id: statusText
 
-            anchors.centerIn: statusBubble
+            anchors.centerIn: parent
             elide: Qt.ElideMiddle
             color: Kirigami.Theme.textColor
 
@@ -627,6 +674,11 @@ Item {
                     statusBubble.visible = false;
                 }
             }
+        }
+
+        Behavior on opacity {
+            enabled: plasmoid.configuration.enableAnimations
+            NumberAnimation { duration: 200 }
         }
     }
 

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -245,11 +245,11 @@ Item {
     WebEngineView {
         id: webview
 
-        // Dim while loading — CSS blur handles the rest once document is ready
-        opacity: loading ? 0.3 : 1.0
+        // Opacity follows load progress: 0% → 0.3, 100% → 1.0
+        opacity: loading ? 0.3 + (loadProgress / 100) * 0.7 : 1.0
         Behavior on opacity {
             enabled: plasmoid.configuration.enableAnimations
-            NumberAnimation { duration: loading ? 100 : 800; easing.type: Easing.InOutQuad }
+            NumberAnimation { duration: 150; easing.type: Easing.OutQuad }
         }
 
         // Transparent WebEngine background when transparency is enabled
@@ -479,9 +479,14 @@ Item {
 
             request.grant();
         }
-        // CSS blur injection: heavy blur during load, smooth unblur when done
-        function injectUnblur() {
+        // CSS blur follows load progress
+        function updateBlurForProgress(progress) {
+            // blur: 12px at 0% → 0px at 100%
+            var blurPx = Math.round(12 * (1 - progress / 100));
+            var sat = 0.4 + (progress / 100) * 0.6; // 0.4 → 1.0
             var subtle = plasmoid.configuration.enableTransparency ? "blur(0.5px)" : "none";
+            var endFilter = (progress >= 100) ? subtle : ("blur(" + blurPx + "px) saturate(" + sat.toFixed(2) + ")");
+
             webview.runJavaScript("
                 (function() {
                     var s = document.getElementById('_chatai_blur');
@@ -490,20 +495,23 @@ Item {
                         s.id = '_chatai_blur';
                         document.head.appendChild(s);
                     }
-                    // Start blurred, then transition to clear
-                    s.textContent = 'html { filter: blur(12px) saturate(0.4) brightness(0.9); }';
-                    requestAnimationFrame(function() {
-                        s.textContent = 'html { filter: " + subtle + "; transition: filter 1.2s cubic-bezier(0.4, 0, 0.2, 1); }';
-                    });
+                    s.textContent = 'html { filter: " + endFilter + "; transition: filter 0.15s ease-out; }';
                 })();
             ");
+        }
+
+        onLoadProgressChanged: {
+            if (loading)
+                updateBlurForProgress(loadProgress);
         }
 
         onLoadingChanged: {
             injectBrowserSpoof();
 
-            if (!webview.loading) {
-                injectUnblur();
+            if (loading) {
+                updateBlurForProgress(0);
+            } else {
+                updateBlurForProgress(100);
                 checkAndUpdateFavicon();
                 injectTransparencyCSS();
             }

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -344,19 +344,17 @@ Item {
                 }
                 return;
             }
-            if (request.permissionType === WebEnginePermission.MediaAudioCapture || request.permissionType === 1 || request.permissionType === WebEnginePermission.MediaVideoCapture || request.permissionType === 2 || request.permissionType === 5) {
-                let isMicrophoneRequest = request.permissionType === 1 || request.permissionType === WebEnginePermission.MediaAudioCapture;
-                let isWebcamRequest = request.permissionType === 2 || request.permissionType === WebEnginePermission.MediaVideoCapture;
-                let isScreenShareRequest = request.permissionType === 5 || request.permissionType === WebEnginePermission.DesktopAudioVideoCapture;
+            if (request.permissionType === WebEnginePermission.MediaAudioCapture) {
+                plasmoid.configuration.microphoneEnabled ? request.grant() : request.deny();
                 return;
             }
-            // Even if MediaAudioCapture and MediaVideoCapture are allowed, it is still necessary to allow DesktopAudioVideoCapture
-            if (request.permissionType === WebEnginePermission.DesktopAudioVideoCapture || request.permissionType === 3) {
-                if (WebEnginePermission.MediaAudioCapture && WebEnginePermission.MediaVideoCapture) {
-                    request.grant();
-                } else {
-                    request.deny();
-                }
+            if (request.permissionType === WebEnginePermission.MediaVideoCapture) {
+                plasmoid.configuration.webcamEnabled ? request.grant() : request.deny();
+                return;
+            }
+            if (request.permissionType === WebEnginePermission.DesktopAudioVideoCapture) {
+                plasmoid.configuration.screenShareEnabled ? request.grant() : request.deny();
+                return;
             }
 
             request.grant();

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -90,11 +90,6 @@ Item {
         return "file:///" + path.replace(/^\/+/, '');
     }
 
-    function getOpenPath(path) {
-        // To open the file, it cannot have file://
-        return path.replace(/^file:\/+/, '').replace(/^\/+/, '/');
-    }
-
     // Add this helper function before the WebEngineView
     function isDownloadInProgress(fileName) {
         if (!webview || !webview.downloads)
@@ -116,8 +111,7 @@ Item {
 
     onFindBarVisibleChanged: {
         if (findBarVisible) {
-            findField.forceActiveFocus();
-            findField.selectAll();
+            findBarComponent.focusField();
         } else {
             webview.findText(""); // Clear any existing search
         }
@@ -128,58 +122,19 @@ Item {
         onActivated: findBarVisible = true
     }
 
-    PlasmaComponents3.Menu {
+    ContextMenu {
         id: linkContextMenu
 
-        property string link
+        visualParent: webview
+        canGoBack: webview.canGoBack
+        canGoForward: webview.canGoForward
 
-        PlasmaComponents3.MenuItem {
-            text: i18n("Back")
-            icon.name: "go-previous"
-            enabled: webview.canGoBack
-            onTriggered: webview.goBack()
-        }
-
-        PlasmaComponents3.MenuItem {
-            text: i18n("Forward")
-            icon.name: "go-next"
-            enabled: webview.canGoForward
-            onTriggered: webview.goForward()
-        }
-
-        PlasmaComponents3.MenuItem {
-            text: i18n("Reload")
-            icon.name: "view-refresh"
-            onTriggered: reloadPage()
-        }
-
-        PlasmaComponents3.MenuItem {
-            text: i18n("Save as PDF")
-            icon.name: "document-save-as"
-            visible: !linkContextMenu.link
-            onTriggered: printPage()
-        }
-
-        PlasmaComponents3.MenuItem {
-            text: i18n("Save as MHTML")
-            icon.name: "document-save"
-            visible: !linkContextMenu.link
-            onTriggered: saveMHTML()
-        }
-
-        PlasmaComponents3.MenuItem {
-            text: i18n("Open Link in Browser")
-            icon.name: "internet-web-browser"
-            visible: linkContextMenu.link !== ""
-            onTriggered: Qt.openUrlExternally(linkContextMenu.link)
-        }
-
-        PlasmaComponents3.MenuItem {
-            text: i18n("Copy Link Address")
-            icon.name: "edit-copy"
-            visible: linkContextMenu.link !== ""
-            onTriggered: webview.triggerWebAction(WebEngineView.CopyLinkToClipboard)
-        }
+        onBackRequested: webview.goBack()
+        onForwardRequested: webview.goForward()
+        onReloadRequested: reloadPage()
+        onSaveAsPdfRequested: printPage()
+        onSaveAsMHTMLRequested: saveMHTML()
+        onCopyLinkRequested: webview.triggerWebAction(WebEngineView.CopyLinkToClipboard)
     }
 
     WebEngineView {
@@ -636,136 +591,23 @@ Item {
         }
     }
 
-    Column {
+    DownloadBar {
         id: downloadsBar
 
-        visible: webview.downloads.count > 0
-        spacing: 4
+        downloadsModel: webview.downloads
+        downloadCacheRef: webview.downloadCache
 
         anchors {
             left: parent.left
             right: parent.right
             bottom: parent.bottom
         }
-
-        Repeater {
-            model: webview.downloads
-
-            delegate: Rectangle {
-                width: parent.width
-                height: 40
-                color: Kirigami.Theme.backgroundColor
-                opacity: 0.9
-
-                RowLayout {
-                    anchors.fill: parent
-                    anchors.margins: 8
-                    spacing: 8
-
-                    PlasmaComponents3.Label {
-                        text: {
-                            if (model.state === WebEngineDownloadRequest.DownloadCompleted) {
-                                return model.fileName + " - Completed";
-                            }
-                            if (model.isPdfExport) {
-                                return model.fileName + " - Saving PDF...";
-                            }
-                            let progress = Math.round((model.progress || 0) * 100);
-                            let size = "";
-                            if (model.totalBytes > 0) {
-                                let received = (model.receivedBytes / 1024 / 1024).toFixed(1);
-                                let total = (model.totalBytes / 1024 / 1024).toFixed(1);
-                                size = ` (${received}/${total} MB)`;
-                            }
-                            return model.fileName + " - " + progress + "%" + size;
-                        }
-                        Layout.fillWidth: true
-                        elide: Text.ElideMiddle
-                    }
-                    // Progress bar (visible during download)
-                    PlasmaComponents3.ProgressBar {
-                        Layout.fillWidth: true
-                        indeterminate: model.isPdfExport
-                        from: 0
-                        to: 1
-                        value: model.progress || 0
-                        visible: model.state === WebEngineDownloadRequest.DownloadInProgress
-                    }
-                    // Buttons shown after download completion
-                    RowLayout {
-                        visible: model.state === WebEngineDownloadRequest.DownloadCompleted
-                        spacing: 4
-
-                        PlasmaComponents3.Button {
-                            icon.name: "document-open"
-                            PlasmaComponents3.ToolTip.text: i18n("Open file")
-                            PlasmaComponents3.ToolTip.visible: hovered
-                            onClicked: {
-                                if (model.fullPath) {
-                                    let openPath = getOpenPath(model.fullPath);
-                                    Qt.openUrlExternally(openPath);
-                                }
-                            }
-                        }
-
-                        PlasmaComponents3.Button {
-                            icon.name: "folder-open"
-                            PlasmaComponents3.ToolTip.text: i18n("Open folder")
-                            PlasmaComponents3.ToolTip.visible: hovered
-                            onClicked: {
-                                if (model.fullPath) {
-                                    let dirPath = model.fullPath.substring(0, model.fullPath.lastIndexOf("/"));
-                                    let openPath = getOpenPath(dirPath);
-                                    Qt.openUrlExternally(openPath);
-                                }
-                            }
-                        }
-
-                        PlasmaComponents3.Button {
-                            icon.name: "dialog-close"
-                            PlasmaComponents3.ToolTip.text: i18n("Close")
-                            PlasmaComponents3.ToolTip.visible: hovered
-                            onClicked: {
-                                webview.downloads.remove(model.index);
-                            }
-                        }
-                    }
-                    // Cancel button (visible during download)
-                    PlasmaComponents3.Button {
-                        icon.name: "dialog-cancel"
-                        visible: model.state === WebEngineDownloadRequest.DownloadInProgress && !model.isPdfExport
-                        PlasmaComponents3.ToolTip.text: i18n("Cancel")
-                        PlasmaComponents3.ToolTip.visible: hovered
-                        onClicked: {
-                            // Get the cached download object using the unique ID
-                            let downloadData = webview.downloadCache[model.downloadId];
-                            if (downloadData && downloadData.download) {
-                                // Disconnect signal handlers before canceling
-                                downloadData.download.receivedBytesChanged.disconnect(downloadData.bytesConnection);
-                                downloadData.download.stateChanged.disconnect(downloadData.stateConnection);
-
-                                // Cancel the download
-                                downloadData.download.cancel();
-
-                                // Clean up cache
-                                delete webview.downloadCache[model.downloadId];
-
-                                // Remove from downloads model
-                                webview.downloads.remove(index);
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 
-    Rectangle {
-        id: findBar
-        visible: findBarVisible
-        height: visible ? findBarRow.height + Kirigami.Units.smallSpacing * 2 : 0
-        color: Kirigami.Theme.backgroundColor
-        z: 5
+    FindBar {
+        id: findBarComponent
+
+        barVisible: findBarVisible
 
         anchors {
             top: parent.top
@@ -773,71 +615,11 @@ Item {
             right: parent.right
         }
 
-        RowLayout {
-            id: findBarRow
-
-            anchors {
-                left: parent.left
-                right: parent.right
-                top: parent.top
-                margins: Kirigami.Units.smallSpacing
-            }
-
-            spacing: Kirigami.Units.smallSpacing
-
-            PlasmaComponents3.TextField {
-                id: findField
-
-                Layout.fillWidth: true
-
-                placeholderText: i18n("Find in page...")
-                onTextChanged: if (text)
-                    webview.findText(text)
-                onAccepted: webview.findText(text)
-                Keys.onEscapePressed: findBarVisible = false
-
-                Component.onCompleted: {
-                    if (findBarVisible) {
-                        forceActiveFocus();
-                    }
-                }
-            }
-
-            PlasmaComponents3.Button {
-                icon.name: "go-up"
-                display: PlasmaComponents3.AbstractButton.IconOnly
-                onClicked: webview.findText(findField.text, WebEngineView.FindBackward)
-                PlasmaComponents3.ToolTip.text: i18n("Find previous")
-                PlasmaComponents3.ToolTip.visible: hovered
-                enabled: findField.text !== ""
-            }
-
-            PlasmaComponents3.Button {
-                icon.name: "go-down"
-                display: PlasmaComponents3.AbstractButton.IconOnly
-                onClicked: webview.findText(findField.text)
-                PlasmaComponents3.ToolTip.text: i18n("Find next")
-                PlasmaComponents3.ToolTip.visible: hovered
-                enabled: findField.text !== ""
-            }
-
-            PlasmaComponents3.Button {
-                icon.name: "dialog-close"
-                display: PlasmaComponents3.AbstractButton.IconOnly
-                PlasmaComponents3.ToolTip.text: i18n("Close")
-                PlasmaComponents3.ToolTip.visible: hovered
-                onClicked: {
-                    findBarVisible = false;
-                    webview.findText("");
-                }
-            }
-        }
-
-        Behavior on height {
-            NumberAnimation {
-                duration: Kirigami.Units.shortDuration
-                easing.type: Easing.InOutQuad
-            }
+        onFindRequested: text => webview.findText(text)
+        onFindPreviousRequested: text => webview.findText(text, WebEngineView.FindBackward)
+        onClosed: {
+            findBarVisible = false;
+            webview.findText("");
         }
     }
 }

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -479,13 +479,11 @@ Item {
 
             request.grant();
         }
-        // CSS blur follows load progress
+        // CSS backdrop blur follows load progress — blurs background only, text stays sharp
         function updateBlurForProgress(progress) {
-            // blur: 12px at 0% → 0px at 100%
             var blurPx = Math.round(12 * (1 - progress / 100));
-            var sat = 0.4 + (progress / 100) * 0.6; // 0.4 → 1.0
-            var subtle = plasmoid.configuration.enableTransparency ? "blur(0.5px)" : "none";
-            var endFilter = (progress >= 100) ? subtle : ("blur(" + blurPx + "px) saturate(" + sat.toFixed(2) + ")");
+            var overlayAlpha = (1 - progress / 100) * 0.3; // 0.3 at 0% → 0 at 100%
+            var subtle = plasmoid.configuration.enableTransparency ? 0.5 : 0;
 
             webview.runJavaScript("
                 (function() {
@@ -495,7 +493,39 @@ Item {
                         s.id = '_chatai_blur';
                         document.head.appendChild(s);
                     }
-                    s.textContent = 'html { filter: " + endFilter + "; transition: filter 0.15s ease-out; }';
+
+                    var blur = " + blurPx + ";
+                    var alpha = " + overlayAlpha.toFixed(3) + ";
+                    var subtle = " + subtle + ";
+
+                    if (blur <= 0 && subtle <= 0) {
+                        s.textContent = '#_chatai_blur_overlay { display: none; }';
+                        return;
+                    }
+
+                    var finalBlur = blur > 0 ? blur : subtle;
+                    var finalAlpha = blur > 0 ? alpha : 0;
+
+                    s.textContent = `
+                        #_chatai_blur_overlay {
+                            position: fixed;
+                            inset: 0;
+                            z-index: 99999;
+                            pointer-events: none;
+                            backdrop-filter: blur(${finalBlur}px);
+                            -webkit-backdrop-filter: blur(${finalBlur}px);
+                            background: rgba(0,0,0,${finalAlpha});
+                            transition: backdrop-filter 0.15s ease-out, background 0.15s ease-out,
+                                        -webkit-backdrop-filter 0.15s ease-out;
+                        }
+                    `;
+
+                    // Create overlay element if needed
+                    if (!document.getElementById('_chatai_blur_overlay')) {
+                        var div = document.createElement('div');
+                        div.id = '_chatai_blur_overlay';
+                        document.documentElement.appendChild(div);
+                    }
                 })();
             ");
         }

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -122,18 +122,58 @@ Item {
         onActivated: findBarVisible = true
     }
 
-    ContextMenu {
+    PlasmaComponents3.Menu {
         id: linkContextMenu
 
-        canGoBack: webview.canGoBack
-        canGoForward: webview.canGoForward
+        property string link: ""
 
-        onBackRequested: webview.goBack()
-        onForwardRequested: webview.goForward()
-        onReloadRequested: reloadPage()
-        onSaveAsPdfRequested: printPage()
-        onSaveAsMHTMLRequested: saveMHTML()
-        onCopyLinkRequested: webview.triggerWebAction(WebEngineView.CopyLinkToClipboard)
+        PlasmaComponents3.MenuItem {
+            text: i18n("Back")
+            icon.name: "go-previous"
+            enabled: webview.canGoBack
+            onTriggered: webview.goBack()
+        }
+
+        PlasmaComponents3.MenuItem {
+            text: i18n("Forward")
+            icon.name: "go-next"
+            enabled: webview.canGoForward
+            onTriggered: webview.goForward()
+        }
+
+        PlasmaComponents3.MenuItem {
+            text: i18n("Reload")
+            icon.name: "view-refresh"
+            onTriggered: reloadPage()
+        }
+
+        PlasmaComponents3.MenuItem {
+            text: i18n("Save as PDF")
+            icon.name: "document-save-as"
+            visible: !linkContextMenu.link
+            onTriggered: printPage()
+        }
+
+        PlasmaComponents3.MenuItem {
+            text: i18n("Save as MHTML")
+            icon.name: "document-save"
+            visible: !linkContextMenu.link
+            onTriggered: saveMHTML()
+        }
+
+        PlasmaComponents3.MenuItem {
+            text: i18n("Open Link in Browser")
+            icon.name: "internet-web-browser"
+            visible: linkContextMenu.link !== ""
+            onTriggered: Qt.openUrlExternally(linkContextMenu.link)
+        }
+
+        PlasmaComponents3.MenuItem {
+            text: i18n("Copy Link Address")
+            icon.name: "edit-copy"
+            visible: linkContextMenu.link !== ""
+            onTriggered: webview.triggerWebAction(WebEngineView.CopyLinkToClipboard)
+        }
     }
 
     WebEngineView {

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -125,7 +125,6 @@ Item {
     ContextMenu {
         id: linkContextMenu
 
-        visualParent: webview
         canGoBack: webview.canGoBack
         canGoForward: webview.canGoForward
 

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -198,7 +198,6 @@ Item {
         // Inject CSS to make the website background semi-transparent
         function injectTransparencyCSS() {
             if (!plasmoid.configuration.enableTransparency) {
-                // Remove injected style if transparency was disabled
                 webview.runJavaScript("
                     var el = document.getElementById('_chatai_transparency');
                     if (el) el.remove();
@@ -206,32 +205,41 @@ Item {
                 return;
             }
 
-            var alpha = plasmoid.configuration.backgroundTransparency;
+            var opacity = plasmoid.configuration.backgroundTransparency;
             webview.runJavaScript("
                 (function() {
                     var styleId = '_chatai_transparency';
                     var existing = document.getElementById(styleId);
                     if (existing) existing.remove();
 
+                    // Grab computed bg colors and make them semi-transparent
+                    var targets = document.querySelectorAll(
+                        'html, body, body > *:first-child, body > div:first-of-type, ' +
+                        'main, #__next, #root, #app, .app, ' +
+                        '[class*=\"layout\"], [class*=\"Layout\"], ' +
+                        '[class*=\"container\"], [class*=\"Container\"], ' +
+                        '[class*=\"wrapper\"], [class*=\"Wrapper\"]'
+                    );
+
+                    var css = 'html, body { background-color: transparent !important; }\\n';
+
+                    targets.forEach(function(el) {
+                        var bg = getComputedStyle(el).backgroundColor;
+                        if (bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent') {
+                            // Parse rgb/rgba and apply opacity
+                            var match = bg.match(/rgba?\\((\\d+),\\s*(\\d+),\\s*(\\d+)/);
+                            if (match) {
+                                var r = match[1], g = match[2], b = match[3];
+                                var selector = el.id ? '#' + el.id :
+                                    el.tagName.toLowerCase() + (el.className ? '.' + el.className.split(' ')[0] : '');
+                                css += selector + ' { background-color: rgba(' + r + ',' + g + ',' + b + ',' + " + opacity + " + ') !important; }\\n';
+                            }
+                        }
+                    });
+
                     var style = document.createElement('style');
                     style.id = styleId;
-                    style.textContent = `
-                        html, body {
-                            background-color: rgba(0, 0, 0, 0) !important;
-                        }
-                        body > *:first-child,
-                        body > div:first-of-type,
-                        main, #__next, #root, #app, .app,
-                        [class*='layout'], [class*='Layout'],
-                        [class*='container'], [class*='Container'],
-                        [class*='wrapper'], [class*='Wrapper'] {
-                            background-color: color-mix(
-                                in srgb,
-                                currentcolor 0%,
-                                transparent calc((1 - " + alpha + ") * 100%)
-                            ) !important;
-                        }
-                    `;
+                    style.textContent = css;
                     document.head.appendChild(style);
                 })();
             ");

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -288,9 +288,33 @@ Item {
                         return m ? { r: m[1], g: m[2], b: m[3] } : null;
                     }
 
+                    // Check if element is chat content (input, output, messages) — never apply transparency
+                    function isChatContent(el) {
+                        var tag = el.tagName.toLowerCase();
+                        // Interactive input elements
+                        if (['input', 'textarea', 'select', 'button', 'fieldset', 'form', 'p', 'pre', 'code', 'li', 'ol', 'ul', 'blockquote', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'a', 'strong', 'em', 'table'].indexOf(tag) >= 0) return true;
+                        if (el.isContentEditable || el.getAttribute('contenteditable') === 'true') return true;
+                        var role = el.getAttribute('role') || '';
+                        if (['textbox', 'searchbox', 'combobox', 'listbox', 'dialog', 'form', 'article', 'log', 'status'].indexOf(role) >= 0) return true;
+                        var cls = (el.className && typeof el.className === 'string') ? el.className.toLowerCase() : '';
+                        // Input areas
+                        if (cls.match(/input|textarea|chat-input|prompt|editor|compose|message-input|ql-editor|ql-container|rich-textarea|text-input|send-button|input-area/)) return true;
+                        // Chat output / messages
+                        if (cls.match(/message|response|answer|reply|conversation|chat-turn|turn-|assistant|user-|bot-|markdown|prose|result|output/)) return true;
+                        // Data attributes commonly used for chat
+                        if (el.getAttribute('data-message-id') || el.getAttribute('data-testid')?.match(/message|conversation|turn/)) return true;
+                        // Contains text content directly (likely a message)
+                        if (el.querySelectorAll('textarea, input, [contenteditable=true], [role=textbox], .ql-editor').length > 0) return true;
+                        return false;
+                    }
+
                     function classifyElement(el) {
                         var rect = el.getBoundingClientRect();
                         if (rect.width < 10 || rect.height < 10) return 'skip';
+
+                        // Never touch interactive/input areas
+                        if (isChatContent(el)) return 'skip';
+
                         var style = getComputedStyle(el);
                         var tag = el.tagName.toLowerCase();
                         var role = el.getAttribute('role') || '';
@@ -326,6 +350,9 @@ Item {
                     allEls.forEach(function(el) {
                         var sel = makeSelector(el);
                         if (!sel || processed.has(sel)) return;
+
+                        // Skip interactive areas and their ancestors
+                        if (isChatContent(el)) return;
 
                         var color = parseBgColor(el);
                         if (!color) return;

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -110,6 +110,13 @@ Item {
 
     property bool findBarVisible: false
 
+    // Re-inject transparency CSS when settings change live
+    Connections {
+        target: plasmoid.configuration
+        function onEnableTransparencyChanged() { if (webview.url.toString()) webview.injectTransparencyCSS(); }
+        function onBackgroundTransparencyChanged() { if (webview.url.toString()) webview.injectTransparencyCSS(); }
+    }
+
     onFindBarVisibleChanged: {
         if (findBarVisible) {
             findBarComponent.focusField();
@@ -184,6 +191,51 @@ Item {
         Behavior on opacity {
             enabled: plasmoid.configuration.enableAnimations
             NumberAnimation { duration: 300; easing.type: Easing.InOutQuad }
+        }
+
+        // Transparent WebEngine background when transparency is enabled
+        backgroundColor: plasmoid.configuration.enableTransparency ? "transparent" : Kirigami.Theme.backgroundColor
+
+        // Inject CSS to make the website background semi-transparent
+        function injectTransparencyCSS() {
+            if (!plasmoid.configuration.enableTransparency) {
+                // Remove injected style if transparency was disabled
+                webview.runJavaScript("
+                    var el = document.getElementById('_chatai_transparency');
+                    if (el) el.remove();
+                ");
+                return;
+            }
+
+            var alpha = plasmoid.configuration.backgroundTransparency;
+            webview.runJavaScript("
+                (function() {
+                    var styleId = '_chatai_transparency';
+                    var existing = document.getElementById(styleId);
+                    if (existing) existing.remove();
+
+                    var style = document.createElement('style');
+                    style.id = styleId;
+                    style.textContent = `
+                        html, body {
+                            background-color: rgba(0, 0, 0, 0) !important;
+                        }
+                        body > *:first-child,
+                        body > div:first-of-type,
+                        main, #__next, #root, #app, .app,
+                        [class*='layout'], [class*='Layout'],
+                        [class*='container'], [class*='Container'],
+                        [class*='wrapper'], [class*='Wrapper'] {
+                            background-color: color-mix(
+                                in srgb,
+                                currentcolor 0%,
+                                transparent calc((1 - " + alpha + ") * 100%)
+                            ) !important;
+                        }
+                    `;
+                    document.head.appendChild(style);
+                })();
+            ");
         }
 
         property var downloadCache: ({})
@@ -363,6 +415,7 @@ Item {
         onLoadingChanged: {
             if (!webview.loading) {
                 checkAndUpdateFavicon();
+                injectTransparencyCSS();
             }
 
             var isCompatibleModel = ['duckduckgo', 'chatgpt', 'google', 'claude', 'you'].some(site => plasmoid.configuration.url.includes(site));

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -368,57 +368,60 @@ Item {
 
             var isCompatibleModel = ['duckduckgo', 'chatgpt', 'google', 'claude', 'you'].some(site => plasmoid.configuration.url.includes(site));
 
-            if (isCompatibleModel) {
+            if (isCompatibleModel && !webview.loading) {
                 webview.runJavaScript("
-                    document.addEventListener('keydown', function(event) {
-                        if (event.key === 'Enter' && !event.shiftKey) {
-                            var duckDuckGoButton = document.querySelector('button[aria-label=\"Send\"]');
-                            var chatGPTButton = document.querySelector('button[data-testid=\"send-button\"]');
-                            var googleGeminiButton = document.querySelector('button.send-button');
-                            var claudeButton = document.querySelector('button[aria-label=\"Send Message\"]');
+                    if (!window._chatAIInjected) {
+                        window._chatAIInjected = true;
 
-                            if (duckDuckGoButton) {
-                                event.preventDefault();
-                                duckDuckGoButton.click();
-                                waitForTextareaEnabledAndFocus();
-                            }
+                        document.addEventListener('keydown', function(event) {
+                            if (event.key === 'Enter' && !event.shiftKey) {
+                                var duckDuckGoButton = document.querySelector('button[aria-label=\"Send\"]');
+                                var chatGPTButton = document.querySelector('button[data-testid=\"send-button\"]');
+                                var googleGeminiButton = document.querySelector('button.send-button');
+                                var claudeButton = document.querySelector('button[aria-label=\"Send Message\"]');
 
-                            if (chatGPTButton) {
-                                event.preventDefault();
-                                chatGPTButton.click();
-                                waitForTextareaEnabledAndFocus();
-                            }
+                                if (duckDuckGoButton) {
+                                    event.preventDefault();
+                                    duckDuckGoButton.click();
+                                    waitForTextareaEnabledAndFocus();
+                                }
 
-                            if (googleGeminiButton) {
-                                event.preventDefault();
-                                googleGeminiButton.click();
-                                waitForTextareaEnabledAndFocus();
-                            }
+                                if (chatGPTButton) {
+                                    event.preventDefault();
+                                    chatGPTButton.click();
+                                    waitForTextareaEnabledAndFocus();
+                                }
 
-                            if (claudeButton) {
-                                event.preventDefault();
-                                claudeButton.click();
-                                waitForTextareaEnabledAndFocus();
+                                if (googleGeminiButton) {
+                                    event.preventDefault();
+                                    googleGeminiButton.click();
+                                    waitForTextareaEnabledAndFocus();
+                                }
+
+                                if (claudeButton) {
+                                    event.preventDefault();
+                                    claudeButton.click();
+                                    waitForTextareaEnabledAndFocus();
+                                }
                             }
+                        });
+
+                        function waitForTextareaEnabledAndFocus() {
+                            var interval = 100;
+
+                            var textareaFocusInterval = setInterval(function() {
+                                var textarea = document.querySelector('textarea');
+                                if (textarea && !textarea.disabled) {
+                                    clearInterval(textareaFocusInterval);
+                                    setTimeout(function() {
+                                        textarea.focus();
+                                    }, 100);
+                                }
+                            }, interval);
                         }
-                    });
 
-                    function waitForTextareaEnabledAndFocus() {
-                        var attempts = 0;
-                        var interval = 100;
-
-                        var textareaFocusInterval = setInterval(function() {
-                            var textarea = document.querySelector('textarea');
-                            if (textarea && !textarea.disabled) {
-                                clearInterval(textareaFocusInterval);
-                                setTimeout(function() {
-                                    textarea.focus();
-                                }, 100);
-                            }
-                        }, interval);
+                        waitForTextareaEnabledAndFocus();
                     }
-
-                    waitForTextareaEnabledAndFocus();
                 ");
             }
         }

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -365,7 +365,7 @@ Item {
         onContextMenuRequested: request => {
             // Use default menu for special elements (text fields, selection, etc)
             if (request.isContentEditable || request.selectedText || request.mediaType !== ContextMenuRequest.MediaTypeNone) {
-                request.accepted = false;  // Permite que o menu padrão apareça
+                request.accepted = false;  // Let the default menu appear
                 return;
             }
 

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -608,15 +608,64 @@ Item {
                 `;
             }
 
-            if (!css) return;
-
+            // Inject known CSS or run heuristic fallback
             webview.runJavaScript("
                 (function() {
                     var s = document.getElementById('_chatai_focus');
                     if (s) s.remove();
                     s = document.createElement('style');
                     s.id = '_chatai_focus';
-                    s.textContent = `" + css + "`;
+
+                    var knownCSS = `" + css + "`;
+
+                    if (knownCSS.trim()) {
+                        s.textContent = knownCSS;
+                    } else {
+                        // Heuristic: analyze DOM and hide non-essential elements
+                        var viewW = window.innerWidth;
+                        var hidden = [];
+
+                        // 1. Hide semantic nav/aside/header elements
+                        document.querySelectorAll('nav, aside, [role=\"navigation\"], [role=\"banner\"], [role=\"complementary\"]').forEach(function(el) {
+                            var rect = el.getBoundingClientRect();
+                            // Skip if it's the main content area or tiny
+                            if (rect.width > viewW * 0.6 || rect.height < 20) return;
+                            hidden.push(el);
+                        });
+
+                        // 2. Hide fixed/absolute sidebars (narrow elements pinned to sides)
+                        document.querySelectorAll('div, section').forEach(function(el) {
+                            var style = getComputedStyle(el);
+                            if (style.position !== 'fixed' && style.position !== 'absolute' && style.position !== 'sticky') return;
+                            var rect = el.getBoundingClientRect();
+                            if (rect.width > viewW * 0.35) return; // too wide to be sidebar
+                            if (rect.height < viewW * 0.3) return; // too short to be sidebar
+                            // Likely a sidebar or panel
+                            hidden.push(el);
+                        });
+
+                        // 3. Hide top headers (full-width, short, at top)
+                        document.querySelectorAll('header, [role=\"banner\"]').forEach(function(el) {
+                            var rect = el.getBoundingClientRect();
+                            if (rect.top < 10 && rect.height < 80 && rect.width > viewW * 0.5) {
+                                hidden.push(el);
+                            }
+                        });
+
+                        // Build CSS from detected elements
+                        var css = '';
+                        hidden.forEach(function(el) {
+                            // Tag unique selectors for each element
+                            if (!el.dataset.chataiHidden) {
+                                el.dataset.chataiHidden = '1';
+                            }
+                        });
+                        css = '[data-chatai-hidden=\"1\"] { display: none !important; }\\n';
+                        css += 'main, [role=\"main\"] { margin-left: 0 !important; margin-right: 0 !important; max-width: 100% !important; width: 100% !important; }';
+
+                        s.textContent = css;
+                    }
+
                     document.head.appendChild(s);
                 })();
             ");

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -16,6 +16,11 @@ import org.kde.kirigami as Kirigami
 Item {
     id: webViewRoot
     readonly property string effectiveProfileName: plasmoid.configuration.webEngineProfileName && plasmoid.configuration.webEngineProfileName.length ? plasmoid.configuration.webEngineProfileName : "chat-ai"
+    readonly property string effectiveDownloadPath: {
+        if (plasmoid.configuration.downloadPath)
+            return plasmoid.configuration.downloadPath.toString().replace(/^file:\/\//, '');
+        return StandardPaths.writableLocation(StandardPaths.DownloadLocation);
+    }
 
     function goBackToHomePage() {
         webview.url = plasmoid.configuration.url;
@@ -35,7 +40,7 @@ Item {
 
     function printPage() {
         webview.runJavaScript("document.title", function (title) {
-            let downloadDirectory = plasmoid.configuration.downloadPath ? plasmoid.configuration.downloadPath.toString().replace(/^file:\/\//, '') : StandardPaths.writableLocation(StandardPaths.DownloadLocation);
+            let downloadDirectory = webViewRoot.effectiveDownloadPath;
 
             let timestamp = new Date().toISOString().replace(/[:.]/g, '-');
             let safeName = title.replace(/[^a-z0-9]/gi, '-').toLowerCase();
@@ -53,7 +58,7 @@ Item {
 
     function saveMHTML() {
         webview.runJavaScript("document.title", function (title) {
-            let downloadDirectory = plasmoid.configuration.downloadPath ? plasmoid.configuration.downloadPath.toString().replace(/^file:\/\//, '') : StandardPaths.writableLocation(StandardPaths.DownloadLocation);
+            let downloadDirectory = webViewRoot.effectiveDownloadPath;
 
             let timestamp = new Date().toISOString().replace(/[:.]/g, '-');
             let safeName = title.replace(/[^a-z0-9]/gi, '-').toLowerCase();
@@ -500,12 +505,7 @@ Item {
             httpCacheType: WebEngineProfile.DiskHttpCache
             persistentCookiesPolicy: WebEngineProfile.ForcePersistentCookies
             persistentPermissionsPolicy: WebEngineProfile.AskEveryTime
-            downloadPath: {
-                if (plasmoid.configuration.downloadPath)
-                    return plasmoid.configuration.downloadPath.toString().replace(/^file:\/\//, '');
-
-                return StandardPaths.writableLocation(StandardPaths.DownloadLocation);
-            }
+            downloadPath: webViewRoot.effectiveDownloadPath
             onPresentNotification: function (notification) {
                 showNotification(notification.title, notification.message);
                 notification.show();
@@ -516,7 +516,7 @@ Item {
                     webview.downloads = Qt.createQmlObject('import QtQml; ListModel {}', webview);
                 }
 
-                let downloadDirectory = plasmoid.configuration.downloadPath ? plasmoid.configuration.downloadPath.toString().replace(/^file:\/\//, '') : StandardPaths.writableLocation(StandardPaths.DownloadLocation);
+                let downloadDirectory = webViewRoot.effectiveDownloadPath;
 
                 if (!plasmoid.configuration.downloadPath) {
                     plasmoid.configuration.downloadPath = downloadDirectory;

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -7,7 +7,7 @@ import QtWebEngine
 import org.kde.plasma.components as PlasmaComponents3
 import org.kde.plasma.core as PlasmaCore
 import org.kde.plasma.plasmoid
-import org.kde.notification
+import org.kde.notification 1.0
 import org.kde.kirigami as Kirigami
 
 Item {

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -65,8 +65,67 @@ Item {
         });
     }
 
+    readonly property string chromeDesktopUA: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"
+    readonly property string chromeMobileUA: "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Mobile Safari/537.36"
+
     function getUserAgent() {
-        return plasmoid.configuration.url.includes("https://duckduckgo.com") || plasmoid.configuration.url.includes("x.com/i/grok") ? "Mozilla/5.0 (Linux; Android 9; Mobile) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36" : "";
+        var needsMobile = plasmoid.configuration.url.includes("duckduckgo.com") || plasmoid.configuration.url.includes("x.com/i/grok");
+        if (needsMobile)
+            return chromeMobileUA;
+        if (plasmoid.configuration.spoofChromeBrowser)
+            return chromeDesktopUA;
+        return "";
+    }
+
+    // Spoof browser identity so auth pages (Google, Claude, etc.) work
+    function injectBrowserSpoof() {
+        if (!plasmoid.configuration.spoofChromeBrowser)
+            return;
+
+        webview.runJavaScript("
+            if (!window._chatAISpoofed) {
+                window._chatAISpoofed = true;
+
+                // Spoof navigator properties
+                Object.defineProperty(navigator, 'vendor', { get: function() { return 'Google Inc.'; } });
+                Object.defineProperty(navigator, 'platform', { get: function() { return 'Linux x86_64'; } });
+                Object.defineProperty(navigator, 'webdriver', { get: function() { return false; } });
+                Object.defineProperty(navigator, 'languages', { get: function() { return ['en-US', 'en']; } });
+
+                // Spoof window.chrome
+                if (!window.chrome) {
+                    window.chrome = {
+                        runtime: {},
+                        loadTimes: function() { return {}; },
+                        csi: function() { return {}; },
+                        app: { isInstalled: false }
+                    };
+                }
+
+                // Spoof plugins (Chrome has PDF viewer)
+                Object.defineProperty(navigator, 'plugins', {
+                    get: function() {
+                        return [
+                            { name: 'Chrome PDF Viewer', filename: 'internal-pdf-viewer', description: 'Portable Document Format' },
+                            { name: 'Chromium PDF Viewer', filename: 'internal-pdf-viewer', description: '' }
+                        ];
+                    }
+                });
+
+                // Hide webdriver/automation hints
+                delete navigator.__proto__.webdriver;
+
+                // Spoof permissions API behavior
+                if (navigator.permissions) {
+                    var origQuery = navigator.permissions.query;
+                    navigator.permissions.query = function(params) {
+                        if (params.name === 'notifications')
+                            return Promise.resolve({ state: Notification.permission });
+                        return origQuery.call(navigator.permissions, params);
+                    };
+                }
+            }
+        ");
     }
 
     Notification {
@@ -441,6 +500,7 @@ Item {
         }
 
         onLoadingChanged: {
+            injectBrowserSpoof();
             injectLoadingBlur(webview.loading);
 
             if (!webview.loading) {

--- a/contents/ui/WebView.qml
+++ b/contents/ui/WebView.qml
@@ -168,11 +168,12 @@ Item {
 
     property bool findBarVisible: false
 
-    // Re-inject transparency CSS when settings change live
+    // Re-inject CSS when settings change live
     Connections {
         target: plasmoid.configuration
         function onEnableTransparencyChanged() { if (webview.url.toString()) webview.injectTransparencyCSS(); }
         function onBackgroundTransparencyChanged() { if (webview.url.toString()) webview.injectTransparencyCSS(); }
+        function onFocusModeChanged() { if (webview.url.toString()) webview.injectFocusMode(); }
     }
 
     onFindBarVisibleChanged: {
@@ -530,6 +531,97 @@ Item {
             ");
         }
 
+        // Focus mode: hide sidebars, headers, and non-essential UI per service
+        function injectFocusMode() {
+            if (!plasmoid.configuration.focusMode) {
+                webview.runJavaScript("var el = document.getElementById('_chatai_focus'); if (el) el.remove();");
+                return;
+            }
+
+            var url = webview.url.toString();
+            var css = "";
+
+            if (url.includes("chatgpt.com")) {
+                css = `
+                    /* ChatGPT: hide sidebar, top nav */
+                    nav, div[class*="sidebar"], div[class*="Sidebar"],
+                    div[class*="drawer"], header:has(button[aria-label]) {
+                        display: none !important;
+                    }
+                    main { margin-left: 0 !important; }
+                    div[class*="thread"] { max-width: 100% !important; }
+                `;
+            } else if (url.includes("claude.ai")) {
+                css = `
+                    /* Claude: hide sidebar */
+                    div[class*="sidebar"], div[class*="Sidebar"],
+                    nav, aside, div[data-testid="sidebar"],
+                    div[class*="ConversationList"], div[class*="conversation-list"] {
+                        display: none !important;
+                    }
+                    main, div[class*="main"], div[class*="Main"] {
+                        margin-left: 0 !important;
+                        max-width: 100% !important;
+                    }
+                `;
+            } else if (url.includes("duckduckgo.com")) {
+                css = `
+                    /* DuckDuckGo: hide header, side panels */
+                    header, div[class*="header"], div[class*="Header"],
+                    div[class*="sidebar"], aside {
+                        display: none !important;
+                    }
+                    main { margin: 0 auto !important; max-width: 100% !important; }
+                `;
+            } else if (url.includes("gemini.google.com")) {
+                css = `
+                    /* Gemini: hide side nav, top bar */
+                    mat-sidenav, side-navigation, side-navigation-v2,
+                    header, .header-bar, mat-toolbar,
+                    c-wiz > header, div[class*="side-nav"] {
+                        display: none !important;
+                    }
+                    mat-sidenav-content, .main-container {
+                        margin-left: 0 !important;
+                        max-width: 100% !important;
+                    }
+                `;
+            } else if (url.includes("chat.deepseek.com")) {
+                css = `
+                    /* DeepSeek: hide sidebar */
+                    div[class*="sidebar"], div[class*="Sidebar"],
+                    nav, aside {
+                        display: none !important;
+                    }
+                    main, div[class*="main"] {
+                        margin-left: 0 !important;
+                        max-width: 100% !important;
+                    }
+                `;
+            } else if (url.includes("copilot.microsoft.com")) {
+                css = `
+                    /* Copilot: hide side elements */
+                    aside, nav, div[class*="sidebar"], div[class*="Sidebar"] {
+                        display: none !important;
+                    }
+                    main { margin: 0 !important; max-width: 100% !important; }
+                `;
+            }
+
+            if (!css) return;
+
+            webview.runJavaScript("
+                (function() {
+                    var s = document.getElementById('_chatai_focus');
+                    if (s) s.remove();
+                    s = document.createElement('style');
+                    s.id = '_chatai_focus';
+                    s.textContent = `" + css + "`;
+                    document.head.appendChild(s);
+                })();
+            ");
+        }
+
         onLoadProgressChanged: {
             if (loading)
                 updateBlurForProgress(loadProgress);
@@ -544,6 +636,7 @@ Item {
                 updateBlurForProgress(100);
                 checkAndUpdateFavicon();
                 injectTransparencyCSS();
+                injectFocusMode();
             }
 
             var isCompatibleModel = ['duckduckgo', 'chatgpt', 'google', 'claude', 'you'].some(site => plasmoid.configuration.url.includes(site));

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -9,9 +9,13 @@ PlasmoidItem {
     id: root
 
     // Translucent background lets compositor blur the desktop behind the popup
-    backgroundHints: plasmoid.configuration.enableTransparency
-        ? PlasmaCore.Types.TranslucentBackground
-        : PlasmaCore.Types.DefaultBackground
+    Binding {
+        target: plasmoid
+        property: "backgroundHints"
+        value: plasmoid.configuration.enableTransparency
+            ? PlasmaCore.Types.TranslucentBackground
+            : PlasmaCore.Types.DefaultBackground
+    }
 
     // Define the available chat models and their properties
     // This property combines both predefined and custom sites

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -137,6 +137,14 @@ PlasmoidItem {
         }
     }
 
+    // Hide popup when clicking outside (unless pinned)
+    Binding {
+        target: root
+        property: "hideOnWindowDeactivate"
+        value: !plasmoid.configuration.pin
+        restoreMode: Binding.RestoreBinding
+    }
+
     // Widget appearance when collapsed (icon only)
     compactRepresentation: CompactRepresentation {
         id: compactRep

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -198,6 +198,15 @@ PlasmoidItem {
             }
         }
 
+        // Rounded clip container
+        Rectangle {
+            id: clipContainer
+            anchors.fill: parent
+            anchors.margins: Kirigami.Units.smallSpacing
+            radius: Kirigami.Units.largeSpacing
+            color: "transparent"
+            clip: true
+
         ColumnLayout {
             id: mainLayout
             anchors.fill: parent
@@ -443,5 +452,6 @@ PlasmoidItem {
             target: root
         }
         } // ColumnLayout
+        } // clipContainer
     } // Item fullRep
 }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -8,6 +8,11 @@ import org.kde.plasma.plasmoid
 PlasmoidItem {
     id: root
 
+    // Translucent background lets compositor blur the desktop behind the popup
+    backgroundHints: plasmoid.configuration.enableTransparency
+        ? PlasmaCore.Types.TranslucentBackground
+        : PlasmaCore.Types.DefaultBackground
+
     // Define the available chat models and their properties
     // This property combines both predefined and custom sites
     property var models: {

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -9,13 +9,9 @@ PlasmoidItem {
     id: root
 
     // Translucent background lets compositor blur the desktop behind the popup
-    Binding {
-        target: plasmoid
-        property: "backgroundHints"
-        value: plasmoid.configuration.enableTransparency
-            ? PlasmaCore.Types.TranslucentBackground
-            : PlasmaCore.Types.DefaultBackground
-    }
+    Plasmoid.backgroundHints: plasmoid.configuration.enableTransparency
+        ? PlasmaCore.Types.TranslucentBackground
+        : PlasmaCore.Types.DefaultBackground
 
     // Define the available chat models and their properties
     // This property combines both predefined and custom sites

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -9,7 +9,7 @@ PlasmoidItem {
     id: root
 
     // Translucent background lets compositor blur the desktop behind the popup
-    Plasmoid.backgroundHints: plasmoid.configuration.enableTransparency
+    Plasmoid.backgroundHints: plasmoid.configuration.enableBlur
         ? PlasmaCore.Types.TranslucentBackground
         : PlasmaCore.Types.DefaultBackground
 
@@ -279,6 +279,9 @@ PlasmoidItem {
             onNavigateBackRequested: webviewRoot.goBack()
             onNavigateForwardRequested: webviewRoot.goForward()
             onPrintPageRequested: webviewRoot.printPage()
+            onInjectTransparencyRequested: {
+                if (webviewRoot) webviewRoot.toggleBlur();
+            }
             onToggleSearchRequested: {
                 if (webviewRoot && webviewRoot.findBarVisible !== undefined) {
                     webviewRoot.findBarVisible = !webviewRoot.findBarVisible;
@@ -304,7 +307,7 @@ PlasmoidItem {
             Timer {
                 id: hideTimer
 
-                interval: 4000
+                interval: 1500
                 onTriggered: {
                     if (!headerRoot.isInteracting && !headerMouseArea.containsMouse)
                         headerRoot.headerVisible = false;

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -163,14 +163,39 @@ PlasmoidItem {
         Layout.minimumWidth: Kirigami.Units.gridUnit * 28
         Layout.minimumHeight: Kirigami.Units.gridUnit * 39
 
-        // Accent border around the whole widget
+        // Accent glow around the widget
         Rectangle {
+            id: glowOuter
             anchors.fill: parent
+            anchors.margins: -6
             color: "transparent"
-            border.color: plasmoid.configuration.accentBorder ? Kirigami.Theme.highlightColor : "transparent"
-            border.width: plasmoid.configuration.accentBorder ? plasmoid.configuration.accentBorderWidth : 0
-            radius: Kirigami.Units.smallSpacing
-            z: 10
+            radius: Kirigami.Units.largeSpacing
+            visible: plasmoid.configuration.accentBorder
+            z: -1
+
+            Rectangle {
+                anchors.fill: parent
+                radius: parent.radius
+                color: "transparent"
+                border.width: 6
+                border.color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.25)
+            }
+            Rectangle {
+                anchors.fill: parent
+                anchors.margins: 2
+                radius: parent.radius - 2
+                color: "transparent"
+                border.width: 4
+                border.color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.4)
+            }
+            Rectangle {
+                anchors.fill: parent
+                anchors.margins: 4
+                radius: parent.radius - 4
+                color: "transparent"
+                border.width: 2
+                border.color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.6)
+            }
         }
 
         ColumnLayout {

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -146,11 +146,28 @@ PlasmoidItem {
     }
 
     // Widget appearance when expanded (full view)
-    fullRepresentation: ColumnLayout {
-        id: mainLayout
+    fullRepresentation: Item {
+        id: fullRep
 
         // Expose WebView root for other components
         property alias webviewRoot: webviewLoader.item
+
+        Layout.minimumWidth: Kirigami.Units.gridUnit * 28
+        Layout.minimumHeight: Kirigami.Units.gridUnit * 39
+
+        // Accent border around the whole widget
+        Rectangle {
+            anchors.fill: parent
+            color: "transparent"
+            border.color: plasmoid.configuration.accentBorder ? Kirigami.Theme.highlightColor : "transparent"
+            border.width: plasmoid.configuration.accentBorder ? plasmoid.configuration.accentBorderWidth : 0
+            radius: Kirigami.Units.smallSpacing
+            z: 10
+        }
+
+        ColumnLayout {
+            id: mainLayout
+            anchors.fill: parent
         // Update the property to use Types.Location and add the change monitor
         property bool reverseLayout: plasmoid.location === PlasmaCore.Types.TopEdge
 
@@ -174,9 +191,6 @@ PlasmoidItem {
             }
         }
 
-        // Set minimum dimensions for the expanded view
-        Layout.minimumWidth: Kirigami.Units.gridUnit * 28
-        Layout.minimumHeight: Kirigami.Units.gridUnit * 39
         Component.onCompleted: {
             reorderComponents();
         }
@@ -398,5 +412,6 @@ PlasmoidItem {
 
             target: root
         }
-    }
+        } // ColumnLayout
+    } // Item fullRep
 }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -206,9 +206,8 @@ PlasmoidItem {
             models: root.models
             Layout.fillWidth: true
             z: 2 // Increase the z-index to ensure it is above the MouseArea
-            // Callback to close the WebView and collapse the widget
+            // Callback to collapse the widget (WebView stays loaded for fast reopen)
             closeWebViewCallback: function () {
-                webviewLoader.active = false;
                 root.expanded = false;
             }
             // Handle navigation
@@ -356,31 +355,25 @@ PlasmoidItem {
             Layout.alignment: Qt.AlignTop
         }
 
-        // WebView loader that manages the web content
+        // WebView loader — once loaded, stays alive for instant reopen
         Loader {
             id: webviewLoader
 
-            // Improved the loading of the WebView & Added Error Handling
-            active: root.expanded || item !== null || plasmoid.configuration.loadOnStartup
-            asynchronous: true
+            active: false
             source: "WebView.qml"
             Layout.fillWidth: true
             Layout.fillHeight: true
-            Layout.topMargin: 0
 
-            // Add status handling
             onStatusChanged: {
-                if (status === Loader.Error) {
+                if (status === Loader.Error)
                     console.error("Failed to load WebView.qml");
-                }
             }
         }
 
-        // Monitor plasmoid expansion state
+        // Activate WebView on first expand, keep it alive after that
         Connections {
-            // Activate WebView when plasmoid is expanded
             function onExpandedChanged() {
-                if (root.expanded)
+                if (root.expanded && !webviewLoader.active)
                     webviewLoader.active = true;
             }
 

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -291,13 +291,13 @@ PlasmoidItem {
                 }
             }
 
-            // Timer for hiding
+            // Timer for hiding — only hides if mouse is away AND no interaction
             Timer {
                 id: hideTimer
 
-                interval: 2000
+                interval: 4000
                 onTriggered: {
-                    if (!headerRoot.isInteracting)
+                    if (!headerRoot.isInteracting && !headerMouseArea.containsMouse)
                         headerRoot.headerVisible = false;
                 }
             }
@@ -337,11 +337,9 @@ PlasmoidItem {
                 target: headerRoot
             }
 
-            // Intercept mouse events
+            // Intercept mouse events on the header
             MouseArea {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                Layout.alignment: Qt.AlignTop
+                anchors.fill: parent
                 hoverEnabled: true
                 propagateComposedEvents: true
                 onEntered: {
@@ -360,7 +358,6 @@ PlasmoidItem {
                     headerRoot.isInteracting = false;
                     if (!containsMouse)
                         hideTimer.restart();
-
                     event.accepted = false;
                 }
             }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -206,8 +206,10 @@ PlasmoidItem {
             models: root.models
             Layout.fillWidth: true
             z: 2 // Increase the z-index to ensure it is above the MouseArea
-            // Callback to collapse the widget (WebView stays loaded for fast reopen)
+            // Callback to close/collapse the widget
             closeWebViewCallback: function () {
+                if (!plasmoid.configuration.keepWebEngineAlive)
+                    webviewLoader.active = false;
                 root.expanded = false;
             }
             // Handle navigation

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -209,7 +209,7 @@ PlasmoidItem {
             // Callback to close/collapse the widget
             closeWebViewCallback: function () {
                 if (!plasmoid.configuration.keepWebEngineAlive)
-                    webviewLoader.active = false;
+                    unloadTimer.restart();
                 root.expanded = false;
             }
             // Handle navigation
@@ -357,7 +357,7 @@ PlasmoidItem {
             Layout.alignment: Qt.AlignTop
         }
 
-        // WebView loader — once loaded, stays alive for instant reopen
+        // WebView loader
         Loader {
             id: webviewLoader
 
@@ -372,11 +372,23 @@ PlasmoidItem {
             }
         }
 
-        // Activate WebView on first expand, keep it alive after that
+        // Unload WebEngine after 5 min of inactivity (when keepWebEngineAlive is off)
+        Timer {
+            id: unloadTimer
+            interval: 5 * 60 * 1000
+            onTriggered: {
+                if (!root.expanded)
+                    webviewLoader.active = false;
+            }
+        }
+
         Connections {
             function onExpandedChanged() {
-                if (root.expanded && !webviewLoader.active)
-                    webviewLoader.active = true;
+                if (root.expanded) {
+                    unloadTimer.stop();
+                    if (!webviewLoader.active)
+                        webviewLoader.active = true;
+                }
             }
 
             target: root

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -299,16 +299,16 @@ PlasmoidItem {
                     if (!headerRoot.isInteracting)
                         hideTimer.restart();
                 }
-                onPressed: {
+                onPressed: event => {
                     headerRoot.isInteracting = true;
-                    mouse.accepted = false;
+                    event.accepted = false;
                 }
-                onReleased: {
+                onReleased: event => {
                     headerRoot.isInteracting = false;
                     if (!containsMouse)
                         hideTimer.restart();
 
-                    mouse.accepted = false;
+                    event.accepted = false;
                 }
             }
 
@@ -345,12 +345,12 @@ PlasmoidItem {
                     hideTimer.restart();
             }
             // Pass mouse events to child components
-            onClicked: mouse.accepted = false
-            onPressed: mouse.accepted = false
-            onReleased: mouse.accepted = false
-            onDoubleClicked: mouse.accepted = false
-            onPositionChanged: mouse.accepted = false
-            onPressAndHold: mouse.accepted = false
+            onClicked: event => event.accepted = false
+            onPressed: event => event.accepted = false
+            onReleased: event => event.accepted = false
+            onDoubleClicked: event => event.accepted = false
+            onPositionChanged: event => event.accepted = false
+            onPressAndHold: event => event.accepted = false
 
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignTop

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -141,7 +141,7 @@ PlasmoidItem {
     Binding {
         target: root
         property: "hideOnWindowDeactivate"
-        value: !plasmoid.configuration.pin
+        value: !plasmoid.configuration.keepOpen
         restoreMode: Binding.RestoreBinding
     }
 


### PR DESCRIPTION
## Summary

Visual effects, session persistence, and UI refinements for the plasmoid.

### Blur & Transparency
- Single `enableBlur` toggle for KWin compositor blur + web page transparency
- Toggle button in header bar for quick on/off
- Inline JS injection with resize listener to survive SPA re-renders
- Compositing kick to reliably activate WebEngine transparency

### Session Persistence
- Last visited URL saved and restored across WebView unload/reload

### UI
- Header gradient, accent glow effects
- Chrome browser spoofing for login compatibility
- Rounded corners on popup content
- Extracted FindBar, DownloadBar into separate QML files

### Bug Fix
- Auto-hide header resize no longer breaks page layout

## Test plan
- [ ] Blur applied on page load
- [ ] Toggle blur via header button and settings
- [ ] Auto-hide header doesn't break blur
- [ ] Close/reopen popup restores last page
- [ ] Test on ChatGPT, Claude, DuckDuckGo, Gemini